### PR TITLE
Fix Vercel deployment: set outputDirectory to root

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
   "buildCommand": "",
-  "outputDirectory": "public",
+  "outputDirectory": ".",
   "framework": null
 }


### PR DESCRIPTION
Static files (index.html, manifest.json, sw.js, icons) are at repo root,
not inside a public/ directory. Update outputDirectory from "public" to "."
so Vercel serves files from root directly.