### PR TITLE
fix: improve exercise instructions for safety with left femoral neck stress fracture

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,11 +234,11 @@ const EX = {
   "Parallette L-Sit": {
     requires: ["parallettes"], category: "push",
     sets: [["4","Max Hold"],["4","Max Hold"],["4","Max Hold"]], rest: 60,
-    setup: "Place parallettes shoulder-width apart. Sit between them and grip with palms down.",
-    execution: "Lock elbows, depress scapulae (push shoulders DOWN away from ears), lift your body off the floor. Extend legs straight out parallel to floor. Hold.",
-    nwbCues: "Left leg simply floats alongside the right. Both legs stay straight. If you can't hold the full L-sit, do a tuck hold (knees bent) instead.",
-    why: "Elite gymnastics isometric. Massive core compression + tricep/scapular strength. Completely unloads L4-L5 and hips.",
-    safety: "safe",
+    setup: "Place parallettes shoulder-width apart. Sit between them and grip with palms down. ⚠️ USE SUPPORT HOLD MODIFICATION: legs hang STRAIGHT DOWN, not extended forward.",
+    execution: "SUPPORT HOLD (required modification): Lock elbows, depress scapulae (push shoulders DOWN away from ears), lift your body off the floor. Legs hang STRAIGHT DOWN — do NOT extend them forward. Hold. This trains the same scapular depression and tricep strength without hip flexor activation.",
+    nwbCues: "⚠️ DANGER: A full L-sit (legs horizontal) requires MAXIMAL bilateral iliopsoas activation to hold both legs against gravity. The iliopsoas generates 57-70% of femoral neck strain — this directly loads the fracture site. A tuck hold is WORSE (deeper hip flexion past 90°, violates FAI limit). USE SUPPORT HOLD ONLY (legs hanging down). If you want additional core challenge, add a slight knee raise with the RIGHT leg only.",
+    why: "Support hold: elite gymnastics isometric for scapular depression + tricep strength. Modified from L-sit to eliminate dangerous bilateral hip flexor activation.",
+    safety: "caution",
     swaps: ["Pallof Press"]
   },
 


### PR DESCRIPTION
Critical fixes:
- Side Plank: both sides now trained from right-side-down only (left-side-down
  loads fracture site). Left obliques targeted via overhead reach variation.
- Bird-Dog: prone bench modification as primary option; quadruped flagged as
  requiring PT clearance due to ~90° hip flexion and femoral neck loading.
- Landmine Press: bench required (not floor, protects L4-L5), left-arm pressing
  warns about iliopsoas co-activation with stop cue for hip crease pinch.

Secondary fixes:
- Stir the Pot, T-Spine Mobility: removed quadruped/left-knee-on-ground options
- Nordic Ham Curl: clarified left knee is balance-only, zero force
- Banded Clamshells: spelled out both sides, light band for left, hip angle cap
- Seated Battle Ropes: eliminated V-sit (recruits iliopsoas), bench/chair only
- Mechanical Drop Set: specific NWB transition protocol
- One-Arm Cable Row, Pallof Press: spelled out per-side iliopsoas risk
- Tricep Pushdown, Hammer Curls: seated preferred over standing
- Weighted Pull-Up, Standing Calf Raise, Low-Box Step-Up: transition safety
- All anti-rotation exercises: exhale cue and hip crease stop cue added

https://claude.ai/code/session_01AMt6uocKo1fciCXAirEpsY