### PR TITLE
Remove hardcoded Hevy routine URLs from WORKOUTS and default state

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'nwb-plan-v3';
+const CACHE = 'nwb-plan-v4';
 const URLS = ['/', '/index.html', '/manifest.json', '/icon.svg', '/icon-192.png', '/icon-512.png'];
 
 self.addEventListener('install', e => {


### PR DESCRIPTION
Personal Hevy routine IDs were hardcoded in the WORKOUTS object and as
defaults in the hevyIds useState initializer. Users should configure
their own routine links via the Equip/Settings tab instead.

https://claude.ai/code/session_01TWScywEoQzsjZdZ77iiRqa