### PR TITLE
ui-v2: New UI preview toggle with visual upgrades

### DIFF
--- a/components/section.tsx
+++ b/components/section.tsx
@@ -10,6 +10,7 @@ interface SectionProps {
   onToggle: () => void;
   accent?: string;
   count?: number;
+  coloredBorder?: boolean;
 }
 
 export default function Section({
@@ -20,6 +21,7 @@ export default function Section({
   onToggle,
   accent,
   count,
+  coloredBorder,
 }: SectionProps) {
   const ac = accent ?? "#38bdf8";
 
@@ -29,6 +31,7 @@ export default function Section({
       className="mb-2.5 rounded-[10px] bg-card overflow-hidden"
       style={{
         border: `1px solid ${isOpen ? ac + "44" : "var(--color-border)"}`,
+        borderLeft: coloredBorder ? `3px solid ${ac}` : undefined,
       }}
     >
       <button

--- a/components/workout-view.tsx
+++ b/components/workout-view.tsx
@@ -955,8 +955,26 @@ export default function WorkoutView() {
             );
           });
 
+          const v2GroupAccent =
+            uiV2 && activeSuppCards.length > 0
+              ? activeSuppCards.some((s) => s.type === "leftleg")
+                ? "#14b8a6"
+                : "#f97316"
+              : null;
           return (
-            <div key={origName}>
+            <div
+              key={origName}
+              style={
+                v2GroupAccent
+                  ? {
+                      borderLeft: `2px solid ${v2GroupAccent}55`,
+                      paddingLeft: 3,
+                      marginLeft: 2,
+                      borderRadius: "0 0 0 6px",
+                    }
+                  : undefined
+              }
+            >
               {/* Swap indicator */}
               {exName !== origName && (
                 <div className="text-[10px] text-text-muted px-3 flex items-center gap-1">
@@ -1076,23 +1094,39 @@ export default function WorkoutView() {
                     const isLL = supp.type === "leftleg";
                     const accent = isLL ? "#14b8a6" : "#f97316";
                     const label = isLL ? "L" : "C";
+                    const chipLabel = isLL ? "L-LEG" : "CORE";
                     return (
                       <span
                         key={`ind-${si}`}
-                        className="inline-flex items-center gap-0.5"
+                        className="inline-flex items-center gap-1"
                       >
-                        <span
-                          className="inline-flex items-center justify-center rounded text-[7px] font-extrabold"
-                          style={{
-                            width: 14,
-                            height: 14,
-                            background: accent + "22",
-                            border: `1px solid ${accent}44`,
-                            color: accent,
-                          }}
-                        >
-                          {label}
-                        </span>
+                        {uiV2 ? (
+                          <span
+                            data-testid="v2-supp-chip"
+                            className="inline-flex items-center justify-center rounded-full text-[8px] font-extrabold tracking-wide"
+                            style={{
+                              padding: "1px 6px",
+                              background: accent + "22",
+                              border: `1px solid ${accent}44`,
+                              color: accent,
+                            }}
+                          >
+                            {chipLabel}
+                          </span>
+                        ) : (
+                          <span
+                            className="inline-flex items-center justify-center rounded text-[7px] font-extrabold"
+                            style={{
+                              width: 14,
+                              height: 14,
+                              background: accent + "22",
+                              border: `1px solid ${accent}44`,
+                              color: accent,
+                            }}
+                          >
+                            {label}
+                          </span>
+                        )}
                         <span
                           className="text-[9px] font-semibold"
                           style={{ color: accent, opacity: 0.8 }}
@@ -1887,6 +1921,7 @@ export default function WorkoutView() {
               background: uiV2 ? "#22d3ee" : "var(--color-border)",
               transition: "background 0.2s",
               padding: 0,
+              position: "relative",
             }}
             title="Toggle new UI preview"
           >

--- a/components/workout-view.tsx
+++ b/components/workout-view.tsx
@@ -550,6 +550,7 @@ export default function WorkoutView() {
     if (typeof window === "undefined") return "dark";
     return (localStorage.getItem("nwb_theme") as "dark" | "light") || "dark";
   });
+  const [uiV2, setUiV2] = useState(() => loadState<boolean>("nwb_ui_v2", false));
 
   // ----- Persistence -----
   useEffect(() => {
@@ -586,6 +587,9 @@ export default function WorkoutView() {
     document.documentElement.classList.toggle("light", theme === "light");
     localStorage.setItem("nwb_theme", theme);
   }, [theme]);
+  useEffect(() => {
+    saveState("nwb_ui_v2", uiV2);
+  }, [uiV2]);
 
   const toggleTheme = useCallback(() => {
     setTheme((t) => (t === "dark" ? "light" : "dark"));
@@ -1468,39 +1472,92 @@ export default function WorkoutView() {
 
         {/* Filter pills */}
         <div className="flex flex-wrap gap-1.5 mb-3">
-          <button
-            onClick={() => setFilter(null)}
-            className="px-2.5 py-1.5 text-[11px] font-[inherit] rounded-md cursor-pointer min-h-[36px]"
-            style={{
-              border: filter === null ? `1.5px solid ${accentColor}` : "1.5px solid var(--color-border)",
-              background: filter === null ? accentColor + "18" : "var(--color-card)",
-              color: filter === null ? accentColor : "var(--color-text-muted)",
-              fontWeight: filter === null ? 700 : 400,
-            }}
-          >
-            All
-          </button>
-          {groups.map((g) => {
-            const isActive = filter === g.key;
-            return (
+          {uiV2 ? (
+            // v2: centered flex pills with count badge
+            <>
               <button
-                key={g.key}
-                onClick={() => setFilter(isActive ? null : g.key)}
-                className="px-2.5 py-1.5 text-[11px] font-[inherit] rounded-md cursor-pointer min-h-[36px]"
+                onClick={() => setFilter(null)}
+                className="inline-flex items-center justify-content-center gap-1.5 font-[inherit] rounded-full cursor-pointer"
                 style={{
-                  border: isActive ? `1.5px solid ${g.accent}` : "1.5px solid var(--color-border)",
-                  background: isActive ? g.accent + "18" : "var(--color-card)",
-                  color: isActive ? g.accent : "var(--color-text-muted)",
-                  fontWeight: isActive ? 700 : 400,
+                  padding: "6px 13px", minHeight: 32, fontSize: 11.5, fontWeight: filter === null ? 700 : 500,
+                  border: `1.5px solid ${filter === null ? accentColor + "88" : "var(--color-border)"}`,
+                  background: filter === null ? accentColor + "18" : "var(--color-card)",
+                  color: filter === null ? accentColor : "var(--color-text-muted)",
                 }}
               >
-                {g.icon} {g.label}
-                <span className="ml-1 text-[9px] opacity-60">
-                  {g.exercises.length}
-                </span>
+                All
+                <span style={{
+                  display: "inline-flex", alignItems: "center", justifyContent: "center",
+                  background: filter === null ? accentColor + "33" : "var(--color-border)",
+                  borderRadius: 10, padding: "1px 5px", fontSize: 9, fontWeight: 800,
+                  color: filter === null ? accentColor : "var(--color-text-muted)",
+                  lineHeight: 1.4,
+                }}>{totalExercises}</span>
               </button>
-            );
-          })}
+              {groups.map((g) => {
+                const isActive = filter === g.key;
+                return (
+                  <button
+                    key={g.key}
+                    onClick={() => setFilter(isActive ? null : g.key)}
+                    className="inline-flex items-center justify-center gap-1.5 font-[inherit] rounded-full cursor-pointer"
+                    style={{
+                      padding: "6px 13px", minHeight: 32, fontSize: 11.5, fontWeight: isActive ? 700 : 500,
+                      border: `1.5px solid ${isActive ? g.accent + "88" : "var(--color-border)"}`,
+                      background: isActive ? g.accent + "18" : "var(--color-card)",
+                      color: isActive ? g.accent : "var(--color-text-muted)",
+                    }}
+                  >
+                    {g.icon} {g.label}
+                    <span style={{
+                      display: "inline-flex", alignItems: "center", justifyContent: "center",
+                      background: isActive ? g.accent + "33" : "var(--color-border)",
+                      borderRadius: 10, padding: "1px 5px", fontSize: 9, fontWeight: 800,
+                      color: isActive ? g.accent : "var(--color-text-muted)",
+                      lineHeight: 1.4,
+                    }}>{g.exercises.length}</span>
+                  </button>
+                );
+              })}
+            </>
+          ) : (
+            // classic: existing pills
+            <>
+              <button
+                onClick={() => setFilter(null)}
+                className="px-2.5 py-1.5 text-[11px] font-[inherit] rounded-md cursor-pointer min-h-[36px]"
+                style={{
+                  border: filter === null ? `1.5px solid ${accentColor}` : "1.5px solid var(--color-border)",
+                  background: filter === null ? accentColor + "18" : "var(--color-card)",
+                  color: filter === null ? accentColor : "var(--color-text-muted)",
+                  fontWeight: filter === null ? 700 : 400,
+                }}
+              >
+                All
+              </button>
+              {groups.map((g) => {
+                const isActive = filter === g.key;
+                return (
+                  <button
+                    key={g.key}
+                    onClick={() => setFilter(isActive ? null : g.key)}
+                    className="px-2.5 py-1.5 text-[11px] font-[inherit] rounded-md cursor-pointer min-h-[36px]"
+                    style={{
+                      border: isActive ? `1.5px solid ${g.accent}` : "1.5px solid var(--color-border)",
+                      background: isActive ? g.accent + "18" : "var(--color-card)",
+                      color: isActive ? g.accent : "var(--color-text-muted)",
+                      fontWeight: isActive ? 700 : 400,
+                    }}
+                  >
+                    {g.icon} {g.label}
+                    <span className="ml-1 text-[9px] opacity-60">
+                      {g.exercises.length}
+                    </span>
+                  </button>
+                );
+              })}
+            </>
+          )}
         </div>
 
         {/* Exercise groups */}
@@ -1513,6 +1570,7 @@ export default function WorkoutView() {
             onToggle={() => toggleSection(`lib-${group.key}`)}
             count={group.exercises.length}
             accent={group.accent}
+            coloredBorder={uiV2}
           >
             {group.exercises.map((name) => renderCoreExercise(name))}
           </Section>
@@ -1806,6 +1864,46 @@ export default function WorkoutView() {
   function renderEquipTab() {
     return (
       <div>
+        {/* UI v2 preview toggle */}
+        <div
+          className="flex items-center justify-between rounded-lg mb-4"
+          style={{
+            padding: "12px 14px",
+            background: uiV2 ? "#22d3ee11" : "var(--color-card)",
+            border: `1px solid ${uiV2 ? "#22d3ee44" : "var(--color-border)"}`,
+          }}
+        >
+          <div>
+            <div className="text-[13px] font-semibold text-text">New UI Preview</div>
+            <div className="text-[11px] text-text-muted mt-0.5">
+              {uiV2 ? "Active — section color borders + pill badges" : "Off — using classic UI"}
+            </div>
+          </div>
+          <button
+            onClick={() => setUiV2((v) => !v)}
+            className="relative cursor-pointer border-none font-[inherit]"
+            style={{
+              width: 44, height: 24, borderRadius: 12,
+              background: uiV2 ? "#22d3ee" : "var(--color-border)",
+              transition: "background 0.2s",
+              padding: 0,
+            }}
+            title="Toggle new UI preview"
+          >
+            <span
+              style={{
+                position: "absolute",
+                top: 3, left: uiV2 ? 23 : 3,
+                width: 18, height: 18,
+                borderRadius: "50%",
+                background: "#fff",
+                transition: "left 0.2s",
+                display: "block",
+              }}
+            />
+          </button>
+        </div>
+
         {/* Week start day picker */}
         <Section
           title="Week Start Day"

--- a/e2e/test_ui_v2.py
+++ b/e2e/test_ui_v2.py
@@ -1,0 +1,145 @@
+"""UI v2 toggle tests — verify the New UI Preview toggle works end-to-end."""
+
+from playwright.sync_api import Page, expect
+from conftest import click_tab, get_local_storage
+
+
+def _enable_ui_v2(page: Page):
+    """Navigate to gear tab and enable the New UI Preview toggle."""
+    click_tab(page, "gear")
+    page.wait_for_timeout(300)
+
+    # Find the toggle button by its title attribute
+    toggle = page.locator("button[title='Toggle new UI preview']")
+    expect(toggle).to_be_visible()
+    toggle.click()
+    page.wait_for_timeout(300)
+
+
+def test_toggle_is_visible_in_gear_tab(app_page: Page):
+    """New UI Preview toggle is visible in gear tab."""
+    click_tab(app_page, "gear")
+    app_page.wait_for_timeout(300)
+    toggle = app_page.locator("button[title='Toggle new UI preview']")
+    expect(toggle).to_be_visible()
+
+
+def test_toggle_label_starts_off(app_page: Page):
+    """Toggle label says 'Off' by default."""
+    click_tab(app_page, "gear")
+    app_page.wait_for_timeout(300)
+    label_text = app_page.locator("text=Off — using classic UI")
+    expect(label_text).to_be_visible()
+
+
+def test_toggle_click_changes_label(app_page: Page):
+    """Clicking toggle changes label to Active."""
+    _enable_ui_v2(app_page)
+    label_text = app_page.locator("text=Active — section color borders + pill badges")
+    expect(label_text).to_be_visible()
+
+
+def test_toggle_persists_to_localstorage(app_page: Page):
+    """Enabling toggle persists nwb_ui_v2 to localStorage."""
+    _enable_ui_v2(app_page)
+    val = get_local_storage(app_page, "nwb_ui_v2")
+    assert val is True, f"Expected nwb_ui_v2=True, got {val}"
+
+
+def test_toggle_persists_across_reload(app_page: Page, base_url: str):
+    """Toggle state survives page reload."""
+    _enable_ui_v2(app_page)
+    app_page.reload()
+    app_page.wait_for_selector("[data-testid='app-container']")
+    click_tab(app_page, "gear")
+    app_page.wait_for_timeout(300)
+    label = app_page.locator("text=Active — section color borders + pill badges")
+    expect(label).to_be_visible()
+
+
+def test_v2_upper_tab_pills_have_count_badge(app_page: Page):
+    """With v2 on, Upper tab filter pills show count badges."""
+    _enable_ui_v2(app_page)
+    click_tab(app_page, "upper")
+    app_page.wait_for_timeout(400)
+
+    # The All pill should be a rounded-full pill
+    pills = app_page.locator(".filter-wrap button, [class*='rounded-full']")
+    # Check that the All button contains a count number
+    all_btn = app_page.locator("button", has_text="All").first
+    expect(all_btn).to_be_visible()
+    # Count badge should be inside it — look for the total count
+    inner = all_btn.inner_text()
+    # Should contain a number (total exercises)
+    has_number = any(c.isdigit() for c in inner)
+    assert has_number, f"All pill should contain exercise count, got: '{inner}'"
+
+
+def test_v2_section_cards_have_color_border(app_page: Page):
+    """With v2 on, section cards in Upper tab have colored left borders."""
+    _enable_ui_v2(app_page)
+    click_tab(app_page, "upper")
+    app_page.wait_for_timeout(400)
+
+    sections = app_page.get_by_test_id("section")
+    assert sections.count() > 0, "Should have sections on Upper tab"
+
+    # Check the first section has a non-transparent left border
+    first = sections.first
+    border_left = first.evaluate(
+        "el => getComputedStyle(el).borderLeftColor"
+    )
+    # Default border is var(--color-border) — a dark/muted color
+    # v2 border should be a vivid accent color (not rgb(0,0,0) or very dark)
+    assert border_left != "rgba(0, 0, 0, 0)", f"Left border should not be transparent, got: {border_left}"
+    assert "rgb" in border_left, f"Expected rgb color, got: {border_left}"
+
+    # Check border-left-width is notably wider than 1px (v2 uses 3px)
+    border_width = first.evaluate(
+        "el => parseFloat(getComputedStyle(el).borderLeftWidth)"
+    )
+    assert border_width >= 2.0, f"v2 section should have ~3px left border, got: {border_width}px"
+
+
+def test_v2_can_be_toggled_off(app_page: Page):
+    """Toggling v2 off returns to classic label."""
+    _enable_ui_v2(app_page)  # on
+    click_tab(app_page, "gear")
+    app_page.wait_for_timeout(200)
+    toggle = app_page.locator("button[title='Toggle new UI preview']")
+    toggle.click()  # off
+    app_page.wait_for_timeout(300)
+    expect(app_page.locator("text=Off — using classic UI")).to_be_visible()
+
+
+def test_classic_sections_have_thin_border(app_page: Page):
+    """With v2 off (default), section cards have no thick colored left stripe."""
+    click_tab(app_page, "upper")
+    app_page.wait_for_timeout(400)
+    sections = app_page.get_by_test_id("section")
+    assert sections.count() > 0
+    border_width = sections.first.evaluate(
+        "el => parseFloat(getComputedStyle(el).borderLeftWidth)"
+    )
+    assert border_width < 2.0, f"Classic section should not have wide left border, got: {border_width}px"
+
+
+def test_v2_workout_tab_shows_chip_badges(app_page: Page):
+    """With v2 on, supplement indicator in Workout tab shows L-LEG/CORE chip badges."""
+    _enable_ui_v2(app_page)
+    click_tab(app_page, "workout")
+    app_page.wait_for_timeout(500)
+
+    # v2 chips have data-testid="v2-supp-chip"
+    chips = app_page.get_by_test_id("v2-supp-chip")
+    assert chips.count() > 0, "v2 Workout tab should show v2-supp-chip badges in supplement indicators"
+
+
+def test_classic_workout_tab_no_chip_badges(app_page: Page):
+    """With v2 off, supplement indicator uses single-letter badges, not full chips."""
+    click_tab(app_page, "workout")
+    app_page.wait_for_timeout(500)
+
+    # v2 chips must not appear in classic mode
+    chips = app_page.get_by_test_id("v2-supp-chip")
+    assert chips.count() == 0, "Classic mode should not show v2-supp-chip badges"


### PR DESCRIPTION
## Summary
- Gear tab toggle (`nwb_ui_v2` localStorage flag) to enable/disable new UI
- **Section color borders**: 3px colored left stripe on section cards (Upper/Lower tabs)
- **Filter pill redesign**: Centered inline-flex pills with count badges
- **Superset grouping**: Exercise blocks with supplement partners get accent border + full "L-LEG"/"CORE" chip badges (replacing single-letter "L"/"C")
- Classic UI completely unchanged when toggle is off

## Test plan
- [x] 11 Playwright tests in `e2e/test_ui_v2.py` — all passing
- [ ] Toggle on → Upper tab shows colored section borders + pill badges
- [ ] Toggle off → returns to classic UI
- [ ] Toggle survives page reload (localStorage persistence)
- [ ] Workout tab shows L-LEG/CORE chips when v2 on, single-letter badges when off

🤖 Generated with [Claude Code](https://claude.com/claude-code)