### PR TITLE
feat(core): restore SUPPLEMENT_CORE as opt-in complements

### DIFF
--- a/components/complement-picker.tsx
+++ b/components/complement-picker.tsx
@@ -258,7 +258,7 @@ export default function ComplementPicker({
           {coreAvail.length > 0 && (
             <>
               <div className="text-[10px] font-bold text-text-muted uppercase tracking-wider mb-2">
-                Core focus ({coreAvail.length})
+                Core ({coreAvail.length})
               </div>
               {coreSubtitle && (
                 <div className="text-[10px] text-text-muted mb-2 leading-snug">

--- a/components/complement-picker.tsx
+++ b/components/complement-picker.tsx
@@ -4,6 +4,7 @@ import React, { useMemo } from "react";
 import {
   NEARBY_SUPERSETS,
   SUPPLEMENT_LEFT_LEG,
+  SUPPLEMENT_CORE,
   SUPPLEMENT_EX,
   EQUIP_TO_NEARBY,
   MOBILITY_SUPPLEMENTS,
@@ -13,9 +14,12 @@ import {
 import { cssAlpha } from "@/lib/css-utils";
 
 /**
- * A complement the user can add to an exercise. There are three kinds:
+ * A complement the user can add to an exercise. There are four kinds:
  *  - "nearby"   — one of NEARBY_SUPERSETS (needs nearby equipment)
  *  - "supp"     — a left-leg supplement (looked up in SUPPLEMENT_EX by name)
+ *  - "core"     — a core drill from SUPPLEMENT_CORE for the current workout day
+ *                 (also looked up in SUPPLEMENT_EX by name; distinct kind so it
+ *                 can render with a CORE label + region color)
  *  - "mobility" — a zero-equipment mobility / stretch / breathing drill
  */
 export type ComplementId = string;
@@ -28,12 +32,15 @@ export function encodeNearbyId(ns: NearbySuperset): ComplementId {
 export function encodeSuppId(name: string): ComplementId {
   return `supp${SEP}${name}`;
 }
+export function encodeCoreId(name: string): ComplementId {
+  return `core${SEP}${name}`;
+}
 export function encodeMobilityId(m: MobilitySupplement): ComplementId {
   return `mob${SEP}${m.id}`;
 }
 
 export function decodeComplement(id: ComplementId): {
-  kind: "nearby" | "supp" | "mobility";
+  kind: "nearby" | "supp" | "core" | "mobility";
   value: string;
   sub?: string;
 } {
@@ -45,6 +52,9 @@ export function decodeComplement(id: ComplementId): {
   }
   if (kind === "mob") {
     return { kind: "mobility", value: rest.join(sep) };
+  }
+  if (kind === "core") {
+    return { kind: "core", value: rest.join(sep) };
   }
   return { kind: "supp", value: rest.join(sep) };
 }
@@ -117,6 +127,8 @@ ComplementButton.displayName = "ComplementButton";
 interface ComplementPickerProps {
   exerciseRequires: string[];
   exerciseCategory: string;
+  /** Workout day key (e.g. "Push A") — surfaces day-specific core routine. */
+  workoutKey?: string;
   nearbySelections: string[];
   activeIds: ComplementId[];
   onToggle: (id: ComplementId) => void;
@@ -132,6 +144,7 @@ interface ComplementPickerProps {
 export default function ComplementPicker({
   exerciseRequires,
   exerciseCategory,
+  workoutKey,
   nearbySelections,
   activeIds,
   onToggle,
@@ -139,7 +152,7 @@ export default function ComplementPicker({
 }: ComplementPickerProps) {
   const activeSet = useMemo(() => new Set(activeIds), [activeIds]);
 
-  const { nearbyAvail, suppAvail, mobilityAvail } = useMemo(() => {
+  const { nearbyAvail, suppAvail, coreAvail, coreSubtitle, mobilityAvail } = useMemo(() => {
     const inUseIds = new Set(
       exerciseRequires.map((r) => EQUIP_TO_NEARBY[r]).filter(Boolean),
     );
@@ -157,16 +170,32 @@ export default function ComplementPicker({
       data: (typeof SUPPLEMENT_EX)[string];
     }>;
 
+    const coreDay = workoutKey ? SUPPLEMENT_CORE[workoutKey] : null;
+    const coreAvail = (coreDay?.exercises ?? [])
+      .map((ce) => {
+        const data = SUPPLEMENT_EX[ce.name];
+        return data ? { name: ce.name, region: ce.region, data } : null;
+      })
+      .filter(Boolean) as Array<{
+      name: string;
+      region: string;
+      data: (typeof SUPPLEMENT_EX)[string];
+    }>;
+    const coreSubtitle = coreDay?.subtitle ?? "";
+
     const mobilityAvail = MOBILITY_SUPPLEMENTS.filter((m) =>
       m.appliesTo.includes("all") ||
       m.appliesTo.includes(exerciseCategory as "push" | "pull" | "legs" | "core" | "cardio"),
     );
 
-    return { nearbyAvail, suppAvail, mobilityAvail };
-  }, [exerciseRequires, exerciseCategory, nearbySelections]);
+    return { nearbyAvail, suppAvail, coreAvail, coreSubtitle, mobilityAvail };
+  }, [exerciseRequires, exerciseCategory, workoutKey, nearbySelections]);
 
   const hasAny =
-    nearbyAvail.length > 0 || suppAvail.length > 0 || mobilityAvail.length > 0;
+    nearbyAvail.length > 0 ||
+    suppAvail.length > 0 ||
+    coreAvail.length > 0 ||
+    mobilityAvail.length > 0;
 
   return (
     <div
@@ -265,6 +294,38 @@ export default function ComplementPicker({
                       key={id}
                       label="L-LEG"
                       color="#14b8a6"
+                      title={name}
+                      sets={`${sets[0]}\u00D7${sets[1]}`}
+                      description={data.execution}
+                      active={activeSet.has(id)}
+                      onClick={() => onToggle(id)}
+                    />
+                  );
+                })}
+              </div>
+            </>
+          )}
+
+          {coreAvail.length > 0 && (
+            <>
+              <div className="text-[10px] font-bold text-text-muted uppercase tracking-wider mb-2">
+                Core focus ({coreAvail.length})
+              </div>
+              {coreSubtitle && (
+                <div className="text-[10px] text-text-muted mb-2 leading-snug">
+                  {coreSubtitle} &mdash; day-specific core routine for{" "}
+                  {workoutKey}.
+                </div>
+              )}
+              <div className="space-y-1.5 mb-4">
+                {coreAvail.map(({ name, region, data }) => {
+                  const id = encodeCoreId(name);
+                  const sets = data.sets[0];
+                  return (
+                    <ComplementButton
+                      key={id}
+                      label={region.toUpperCase()}
+                      color="#f97316"
                       title={name}
                       sets={`${sets[0]}\u00D7${sets[1]}`}
                       description={data.execution}

--- a/components/complement-picker.tsx
+++ b/components/complement-picker.tsx
@@ -255,6 +255,38 @@ export default function ComplementPicker({
             </div>
           )}
 
+          {coreAvail.length > 0 && (
+            <>
+              <div className="text-[10px] font-bold text-text-muted uppercase tracking-wider mb-2">
+                Core focus ({coreAvail.length})
+              </div>
+              {coreSubtitle && (
+                <div className="text-[10px] text-text-muted mb-2 leading-snug">
+                  {coreSubtitle} &mdash; day-specific core routine for{" "}
+                  {workoutKey}.
+                </div>
+              )}
+              <div className="space-y-1.5 mb-4">
+                {coreAvail.map(({ name, region, data }) => {
+                  const id = encodeCoreId(name);
+                  const sets = data.sets[0];
+                  return (
+                    <ComplementButton
+                      key={id}
+                      label={region.toUpperCase()}
+                      color="#f97316"
+                      title={name}
+                      sets={`${sets[0]}\u00D7${sets[1]}`}
+                      description={data.execution}
+                      active={activeSet.has(id)}
+                      onClick={() => onToggle(id)}
+                    />
+                  );
+                })}
+              </div>
+            </>
+          )}
+
           {nearbyAvail.length > 0 && (
             <>
               <div className="text-[10px] font-bold text-text-muted uppercase tracking-wider mb-2">
@@ -294,38 +326,6 @@ export default function ComplementPicker({
                       key={id}
                       label="L-LEG"
                       color="#14b8a6"
-                      title={name}
-                      sets={`${sets[0]}\u00D7${sets[1]}`}
-                      description={data.execution}
-                      active={activeSet.has(id)}
-                      onClick={() => onToggle(id)}
-                    />
-                  );
-                })}
-              </div>
-            </>
-          )}
-
-          {coreAvail.length > 0 && (
-            <>
-              <div className="text-[10px] font-bold text-text-muted uppercase tracking-wider mb-2">
-                Core focus ({coreAvail.length})
-              </div>
-              {coreSubtitle && (
-                <div className="text-[10px] text-text-muted mb-2 leading-snug">
-                  {coreSubtitle} &mdash; day-specific core routine for{" "}
-                  {workoutKey}.
-                </div>
-              )}
-              <div className="space-y-1.5 mb-4">
-                {coreAvail.map(({ name, region, data }) => {
-                  const id = encodeCoreId(name);
-                  const sets = data.sets[0];
-                  return (
-                    <ComplementButton
-                      key={id}
-                      label={region.toUpperCase()}
-                      color="#f97316"
                       title={name}
                       sets={`${sets[0]}\u00D7${sets[1]}`}
                       description={data.execution}

--- a/components/equipment-swap-panel.tsx
+++ b/components/equipment-swap-panel.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useMemo } from "react";
 import type { Exercise, MachineVariant } from "@/lib/exercises";
-import { EX, EQUIPMENT } from "@/lib/exercises";
+import { EX, EQUIPMENT, isExerciseAvailable } from "@/lib/exercises";
 import { cssAlpha } from "@/lib/css-utils";
 
 // ── Equipment category mapping ──────────────────────────────────────────
@@ -168,8 +168,7 @@ export default function EquipmentSwapPanel({
           const isExpanded = expandedGroup === group.key;
           const hasUnavailable = group.options.some(
             (o) =>
-              o.ex.requires.length > 0 &&
-              o.ex.requires.some((r) => equipment[r] === false),
+              o.ex.requires.length > 0 && !isExerciseAvailable(o.ex, equipment),
           );
 
           // Count includes variants for the current group
@@ -293,7 +292,7 @@ export default function EquipmentSwapPanel({
                   {group.options.map((option) => {
                     const isUnavailable =
                       option.ex.requires.length > 0 &&
-                      option.ex.requires.some((r) => equipment[r] === false);
+                      !isExerciseAvailable(option.ex, equipment);
                     const safetyColor =
                       option.ex.safety === "caution"
                         ? "var(--color-warning)"

--- a/components/exercise-row.tsx
+++ b/components/exercise-row.tsx
@@ -21,6 +21,12 @@ interface ExerciseRowProps {
   equipment: Record<string, boolean>;
   variantSetupCues?: string[];
   variantLabel?: string;
+  /**
+   * Requires override from the active machine variant. When present it
+   * replaces `ex.requires` for the equipment-chip display so the chips
+   * match what the selected variant actually needs.
+   */
+  variantRequires?: string[];
   /** Superset / complement cards rendered immediately under the header */
   supersetSlot?: React.ReactNode;
   /** Add-complement pill rendered below supersets */
@@ -43,6 +49,7 @@ export default function ExerciseRow({
   equipment,
   variantSetupCues,
   variantLabel,
+  variantRequires,
   supersetSlot,
   addComplementSlot,
   showActionButton = true,
@@ -330,10 +337,13 @@ export default function ExerciseRow({
             )}
           </div>
 
-          {/* Equipment chips */}
-          {ex.requires.length > 0 && (
+          {/* Equipment chips — show the active variant's requires when set,
+              otherwise fall back to the exercise-level requires. */}
+          {(() => {
+            const chipReqs = variantRequires ?? ex.requires;
+            return chipReqs.length > 0 && (
             <div className="flex flex-wrap gap-1.5 mt-3 mb-3">
-              {ex.requires.map((eq) => {
+              {chipReqs.map((eq) => {
                 const eqData = EQUIPMENT[eq];
                 const has = equipment[eq] !== false;
                 return (
@@ -356,7 +366,8 @@ export default function ExerciseRow({
                 );
               })}
             </div>
-          )}
+            );
+          })()}
 
           {/* Rest timer button */}
           {ex.rest > 0 && (

--- a/components/progress-clock.tsx
+++ b/components/progress-clock.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { PROG_START, PROG_DURATION } from "@/lib/program";
 
-// Program start: March 17, 2026 at noon EDT = 16:00 UTC
-const PROG_START = new Date("2026-03-17T16:00:00Z");
-const PROG_DURATION = 42 * 24 * 60 * 60 * 1000; // 6 weeks in ms
 const PROG_END = new Date(PROG_START.getTime() + PROG_DURATION);
 
 function fmt(ms: number) {

--- a/components/workout-view.tsx
+++ b/components/workout-view.tsx
@@ -1145,6 +1145,7 @@ export default function WorkoutView() {
           equipment={equipment}
           variantSetupCues={selectedVariant?.setupCues}
           variantLabel={selectedVariant?.label}
+          variantRequires={selectedVariant?.requires}
           supersetSlot={buildSupersetCards(name, ex, "__core__", null)}
           addComplementSlot={buildAddComplementPill(name, ex)}
         />
@@ -1428,6 +1429,7 @@ export default function WorkoutView() {
                 equipment={equipment}
                 variantSetupCues={selectedVariant?.setupCues}
                 variantLabel={selectedVariant?.label}
+                variantRequires={selectedVariant?.requires}
                 supersetSlot={buildSupersetCards(
                   exName,
                   ex,
@@ -1490,6 +1492,7 @@ export default function WorkoutView() {
                   equipment={equipment}
                   variantSetupCues={selectedVariant?.setupCues}
                   variantLabel={selectedVariant?.label}
+                  variantRequires={selectedVariant?.requires}
                   supersetSlot={buildSupersetCards(name, ex, "__finisher__", null)}
                   addComplementSlot={buildAddComplementPill(name, ex)}
                 />
@@ -1839,6 +1842,7 @@ export default function WorkoutView() {
                 equipment={equipment}
                 variantSetupCues={selectedVariant?.setupCues}
                 variantLabel={selectedVariant?.label}
+                variantRequires={selectedVariant?.requires}
                 supersetSlot={buildSupersetCards(k, ex, "__cardio__", null)}
                 addComplementSlot={buildAddComplementPill(k, ex)}
               />

--- a/components/workout-view.tsx
+++ b/components/workout-view.tsx
@@ -1374,7 +1374,7 @@ export default function WorkoutView() {
             </button>
             {coreSubtitle && (
               <span className="text-[10px] text-text-muted self-center">
-                Core focus: {coreSubtitle} &mdash; tap ＋ Add complement on any
+                Core: {coreSubtitle} &mdash; tap ＋ Add complement on any
                 exercise to pair
               </span>
             )}

--- a/components/workout-view.tsx
+++ b/components/workout-view.tsx
@@ -10,6 +10,7 @@ import {
   NEARBY_EQUIPMENT,
   SCHED,
   PHASES,
+  isExerciseAvailable,
 } from "@/lib/exercises";
 import {
   SUPPLEMENT_CORE,
@@ -752,7 +753,7 @@ export default function WorkoutView() {
     (exName: string): boolean => {
       const ex = EX[exName];
       if (!ex) return true;
-      return ex.requires.every((r) => equipment[r] !== false);
+      return isExerciseAvailable(ex, equipment);
     },
     [equipment],
   );
@@ -1118,8 +1119,7 @@ export default function WorkoutView() {
   function renderCoreExercise(name: string) {
     const ex = EX[name];
     if (!ex) return null;
-    const unavail =
-      !ex || ex.requires.some((r) => equipment[r] === false);
+    const unavail = !isExerciseAvailable(ex, equipment);
     const selMachineId = machineSelections[name];
     const selectedVariant =
       ex.machineVariants?.find((v) => v.id === selMachineId) ?? null;

--- a/components/workout-view.tsx
+++ b/components/workout-view.tsx
@@ -19,6 +19,7 @@ import {
   MOBILITY_SUPPLEMENTS,
 } from "@/lib/supplements";
 import type { Exercise } from "@/lib/exercises";
+import { computeCurrentPhase } from "@/lib/program";
 import Section from "@/components/section";
 import ExerciseRow from "@/components/exercise-row";
 import RemovedRow from "@/components/removed-row";
@@ -512,7 +513,10 @@ const REMOVED_CORE = [
 export default function WorkoutView() {
   // ----- State -----
   const [tab, setTab] = useState(() => loadState<number>("nwb_tab", 0));
-  const [phase, setPhase] = useState(() => loadState<number>("nwb_phase", 0));
+  // Phase is derived from the program start date — always opens on the
+  // week that matches the calendar. Tapping a pill temporarily overrides
+  // within the session but doesn't persist; next mount re-syncs.
+  const [phase, setPhase] = useState(() => computeCurrentPhase());
   const [openSections, setOpenSections] = useState<Record<string, boolean>>(
     () => {
       const sd = loadState<number>("nwb_startDay", 0);
@@ -664,9 +668,6 @@ export default function WorkoutView() {
   useEffect(() => {
     saveState("nwb_tab", tab);
   }, [tab]);
-  useEffect(() => {
-    saveState("nwb_phase", phase);
-  }, [phase]);
   useEffect(() => {
     saveState("nwb_equipment", equipment);
   }, [equipment]);

--- a/components/workout-view.tsx
+++ b/components/workout-view.tsx
@@ -578,7 +578,12 @@ export default function WorkoutView() {
 
   // Complement picker (add equipment-aware supersets / mobility / stretches)
   const [complementPickerFor, setComplementPickerFor] = useState<
-    { exName: string; exerciseRequires: string[]; exerciseCategory: string } | null
+    {
+      exName: string;
+      exerciseRequires: string[];
+      exerciseCategory: string;
+      workoutKey?: string;
+    } | null
   >(null);
 
   // ----- Consolidated day state (date-scoped, clears daily) -----
@@ -858,7 +863,7 @@ export default function WorkoutView() {
     ): React.ReactNode => {
       type Card = {
         key: string;
-        kind: "cable" | "variant" | "nearby" | "leftleg" | "mobility";
+        kind: "cable" | "variant" | "nearby" | "leftleg" | "core" | "mobility";
         label: string;
         color: string;
         title: string;
@@ -940,6 +945,25 @@ export default function WorkoutView() {
             kind: "leftleg",
             label: "L-LEG",
             color: "#14b8a6",
+            title: decoded.value,
+            sets: `${s[0]}\u00D7${s[1]}`,
+            instruction: data.execution,
+            safety: data.nwbCues,
+            removable: true,
+            complementId: id,
+          });
+        } else if (decoded.kind === "core") {
+          const data = SUPPLEMENT_EX[decoded.value];
+          if (!data) continue;
+          const s = data.sets[0];
+          const region = SUPPLEMENT_CORE[workoutKey]?.exercises.find(
+            (ce) => ce.name === decoded.value,
+          )?.region;
+          cards.push({
+            key: id,
+            kind: "core",
+            label: region ? region.toUpperCase() : "CORE",
+            color: "#f97316",
             title: decoded.value,
             sets: `${s[0]}\u00D7${s[1]}`,
             instruction: data.execution,
@@ -1061,7 +1085,7 @@ export default function WorkoutView() {
 
   /** Render the "+ Add complement" pill. */
   const buildAddComplementPill = useCallback(
-    (exName: string, ex: Exercise): React.ReactNode => {
+    (exName: string, ex: Exercise, workoutKey?: string): React.ReactNode => {
       return (
         <button
           data-testid="add-complement"
@@ -1071,6 +1095,7 @@ export default function WorkoutView() {
               exName,
               exerciseRequires: ex.requires,
               exerciseCategory: ex.category,
+              workoutKey,
             });
           }}
           className="w-full mb-3 rounded-xl text-[12px] font-semibold cursor-pointer font-[inherit] min-h-[40px] transition-colors duration-150 flex items-center justify-center gap-1.5"
@@ -1223,6 +1248,22 @@ export default function WorkoutView() {
                   sets: `${s[0]}\u00D7${s[1]}`,
                   instruction: data.execution,
                   safety: data.nwbCues,
+                  rest: data.rest,
+                });
+              } else if (decoded.kind === "core") {
+                const data = SUPPLEMENT_EX[decoded.value];
+                if (!data) continue;
+                const s = data.sets[0];
+                const region = SUPPLEMENT_CORE[workoutKey]?.exercises.find(
+                  (ce) => ce.name === decoded.value,
+                )?.region;
+                supps.push({
+                  type: "core",
+                  name: decoded.value,
+                  sets: `${s[0]}\u00D7${s[1]}`,
+                  instruction: data.execution,
+                  safety: data.nwbCues,
+                  region,
                   rest: data.rest,
                 });
               } else if (decoded.kind === "mobility") {
@@ -1391,7 +1432,7 @@ export default function WorkoutView() {
                   workoutKey,
                   firstCableName,
                 )}
-                addComplementSlot={buildAddComplementPill(exName, ex)}
+                addComplementSlot={buildAddComplementPill(exName, ex, workoutKey)}
               />
             </div>
           );
@@ -3161,6 +3202,7 @@ export default function WorkoutView() {
         <ComplementPicker
           exerciseRequires={complementPickerFor.exerciseRequires}
           exerciseCategory={complementPickerFor.exerciseCategory}
+          workoutKey={complementPickerFor.workoutKey}
           nearbySelections={nearbySelections[complementPickerFor.exName] ?? []}
           activeIds={dayState.complements[complementPickerFor.exName] ?? []}
           onToggle={(id) =>

--- a/components/workout-view.tsx
+++ b/components/workout-view.tsx
@@ -55,7 +55,7 @@ const DEFAULT_HEVY: Record<string, string> = {
   "Legs B": "s5QsLGXsVAy",
 };
 
-const TABS = ["Workout", "Upper", "Lower", "Core", "Cardio", "Safety"];
+const TABS = ["Workout", "Upper", "Lower", "Core", "Cardio"];
 
 const TAB_TIPS = [
   "Today's scheduled workout",
@@ -63,10 +63,10 @@ const TAB_TIPS = [
   "Legs + Recovery exercise library",
   "Core exercises by body part",
   "NWB cardio options",
-  "Injury cues & safety rules",
 ];
 
-// Gear/config tab is accessed via header icon, not in the tab bar
+// Safety + Gear/config live outside the label tab strip as icon buttons
+const SAFETY_TAB_INDEX = 5;
 const GEAR_TAB_INDEX = 6;
 
 const DAY_NAMES = [
@@ -647,7 +647,7 @@ export default function WorkoutView() {
 
   useLayoutEffect(() => {
     if (!uiV2) { pillInitialized.current = false; return; }
-    const activeIdx = tab <= 5 ? tab : 6; // 6 = gear
+    const activeIdx = tab; // 0..4 word tabs, 5 safety icon, 6 gear
     const btn = tabRefs.current[activeIdx];
     const bar = tabBarRef.current;
     if (!btn || !bar) return;
@@ -1374,7 +1374,8 @@ export default function WorkoutView() {
             </button>
             {coreSubtitle && (
               <span className="text-[10px] text-text-muted self-center">
-                Core focus: {coreSubtitle}
+                Core focus: {coreSubtitle} &mdash; tap ＋ Add complement on any
+                exercise to pair
               </span>
             )}
           </div>
@@ -2622,7 +2623,7 @@ export default function WorkoutView() {
     case 4:
       content = renderCardioTab();
       break;
-    case 5:
+    case SAFETY_TAB_INDEX:
       content = renderSafetyTab();
       break;
     case GEAR_TAB_INDEX:
@@ -2750,8 +2751,19 @@ export default function WorkoutView() {
             style={{
               left: pillPos.left,
               width: pillPos.width,
-              background: (tab === 0 ? todayColor : "var(--color-accent)") + "15",
-              border: `1px solid ${(tab === 0 ? todayColor : "var(--color-accent)")}55`,
+              background:
+                (tab === 0
+                  ? todayColor
+                  : tab === SAFETY_TAB_INDEX
+                    ? "var(--color-warning)"
+                    : "var(--color-accent)") + "15",
+              border: `1px solid ${
+                tab === 0
+                  ? todayColor
+                  : tab === SAFETY_TAB_INDEX
+                    ? "var(--color-warning)"
+                    : "var(--color-accent)"
+              }55`,
               transition: pillInitialized.current ? "left 0.3s cubic-bezier(.4,0,.2,1), width 0.3s cubic-bezier(.4,0,.2,1)" : "none",
             }}
           />
@@ -2781,9 +2793,30 @@ export default function WorkoutView() {
         })}
         {/* Divider */}
         <div className="w-px mx-0.5 self-stretch rounded-full" style={{ background: "var(--color-border)" }} />
+        {/* Safety (icon) */}
+        <button
+          ref={(el) => { tabRefs.current[SAFETY_TAB_INDEX] = el; }}
+          data-testid="tab-safety"
+          title="Injury cues & safety rules"
+          onClick={() => setTab(SAFETY_TAB_INDEX)}
+          className={`rounded-xl cursor-pointer font-[inherit] flex items-center justify-center transition-all duration-150 ${tab === SAFETY_TAB_INDEX ? "tab-active" : ""}`}
+          style={{
+            width: 44,
+            minWidth: 44,
+            padding: "12px 0",
+            background: uiV2 ? "transparent" : (tab === SAFETY_TAB_INDEX ? cssAlpha("var(--color-warning)", 8) : "none"),
+            border: uiV2 ? "1px solid transparent" : `1px solid ${tab === SAFETY_TAB_INDEX ? cssAlpha("var(--color-warning)", 33) : "var(--color-border)"}`,
+            color: tab === SAFETY_TAB_INDEX ? "var(--color-warning)" : "var(--color-text-muted)",
+          }}
+        >
+          {/* Shield */}
+          <svg width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+            <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+          </svg>
+        </button>
         {/* Gear / config */}
         <button
-          ref={(el) => { tabRefs.current[6] = el; }}
+          ref={(el) => { tabRefs.current[GEAR_TAB_INDEX] = el; }}
           data-testid="tab-gear"
           title="Equipment & configuration"
           onClick={() => setTab(GEAR_TAB_INDEX)}

--- a/lib/exercises.ts
+++ b/lib/exercises.ts
@@ -305,6 +305,7 @@ export const EX: Record<string, Exercise> = {
           "Set bench to 30-45\u00B0 incline",
           "Have two pairs of dumbbells ready (heavier for press, lighter for raises)",
           "Keep lighter pair within reach to minimize transition time",
+          "No light DBs? Plates (10-25lb) held by the flat side work fine for the lat raise portion",
         ],
       },
       {
@@ -316,7 +317,27 @@ export const EX: Record<string, Exercise> = {
           "Position bench inside the Smith machine at 30-45\u00B0",
           "Set safety catches at chest level",
           "Unrack bar with rotation, press, then re-rack for lat raises with DBs",
+          "Plates held by the flat side also work for the lat raise portion",
         ],
+      },
+      {
+        id: "rogue_rack_barbell",
+        label: "Rogue Rack + Barbell",
+        icon: "\u{1F3CB}\uFE0F",
+        description: "Rogue power rack with adjustable bench at 30-45\u00B0. Barbell for the press; plates (or lighter DBs) for the lat raise portion.",
+        setupCues: [
+          "Set the Rogue adjustable bench to 30-45\u00B0 inside the rack",
+          "Load barbell in the J-cups \u2014 unrack directly to the starting position over the upper chest",
+          "Safety pins set at chest level so you can bail without a spotter",
+          "For the lat raise portion: two plates (10\u201325 lb) held by the flat side work great \u2014 no DBs required",
+        ],
+        superset: {
+          title: "Banded Pallof / Woodchoppers (Seated)",
+          sets: "2\u00D78/side",
+          instruction: "Between press sets: stay seated on the bench with a band anchored to the rack upright at chest height. Alternate Pallof press/hold (8 presses or 10s holds per side) or high-to-low woodchoppers (8 reps/side). Resist rotation \u2014 drive from the thoracic spine, hips stay square.",
+          safety: "Seated throughout \u2014 zero left iliopsoas demand. Band only, no plate load. Keep hip flexion well under 90\u00B0. Anchor the band low enough that the pull never tips you backward.",
+          note: "Zero walking during the superset \u2014 band is anchored on the rack you're already sitting in.",
+        },
       },
     ],
     constraints: {

--- a/lib/exercises.ts
+++ b/lib/exercises.ts
@@ -21,6 +21,12 @@ export interface MachineVariant {
   description: string;
   setupCues: string[];
   superset?: VariantSuperset;
+  /**
+   * Override the exercise-level `requires` when this variant is selected /
+   * available. If omitted the variant inherits the exercise's requires.
+   * Used for cases like a Rogue barbell variant of a DB-default exercise.
+   */
+  requires?: string[];
 }
 
 export interface Exercise {
@@ -51,6 +57,28 @@ export interface EquipmentItem {
   name: string;
   icon: string;
   category: string;
+}
+
+/**
+ * Is this exercise usable given the current equipment map?
+ *
+ * The base config (`ex.requires`) gates availability by default, but if any
+ * `machineVariant` declares its own `requires` and all of those are present,
+ * the exercise is available through that variant even when the base isn't.
+ *
+ * `equipment[key] === false` = user flagged unavailable
+ * `equipment[key] !== false` (undefined or true) = present
+ */
+export function isExerciseAvailable(
+  ex: Exercise,
+  equipment: Record<string, boolean>,
+): boolean {
+  const hasAll = (reqs: string[]) =>
+    reqs.every((r) => equipment[r] !== false);
+  if (hasAll(ex.requires)) return true;
+  return (ex.machineVariants ?? []).some(
+    (v) => v.requires != null && hasAll(v.requires),
+  );
 }
 
 export interface Workout {
@@ -325,6 +353,7 @@ export const EX: Record<string, Exercise> = {
         label: "Rogue Rack + Barbell",
         icon: "\u{1F3CB}\uFE0F",
         description: "Rogue power rack with adjustable bench at 30-45\u00B0. Barbell for the press; plates (or lighter DBs) for the lat raise portion.",
+        requires: ["barbell", "bench"],
         setupCues: [
           "Set the Rogue adjustable bench to 30-45\u00B0 inside the rack",
           "Load barbell in the J-cups \u2014 unrack directly to the starting position over the upper chest",

--- a/lib/program.ts
+++ b/lib/program.ts
@@ -1,0 +1,25 @@
+// Shared program timing constants & helpers.
+// The canonical source for program start — the progress clock and the
+// auto-phase logic both depend on this.
+
+/** Program start: March 17, 2026 at noon EDT = 16:00 UTC */
+export const PROG_START = new Date("2026-03-17T16:00:00Z");
+
+/** 6 weeks in ms. */
+export const PROG_DURATION = 42 * 24 * 60 * 60 * 1000;
+
+/**
+ * Which phase index (0, 1, 2) maps to today's calendar week.
+ *  - phase 0 → weeks 1-2 (Foundation)
+ *  - phase 1 → weeks 3-4 (Build)
+ *  - phase 2 → weeks 5-6 (Peak)
+ * Clamps to [0, 2] so dates outside the 6-week window still resolve.
+ */
+export function computeCurrentPhase(now: Date = new Date()): number {
+  const elapsed = now.getTime() - PROG_START.getTime();
+  if (elapsed < 0) return 0;
+  const week = Math.floor(elapsed / (7 * 24 * 60 * 60 * 1000)) + 1;
+  if (week <= 2) return 0;
+  if (week <= 4) return 1;
+  return 2;
+}


### PR DESCRIPTION
Since the UI refactor in 8122b11, SUPPLEMENT_CORE has been orphaned:
the data still existed but was never surfaced in the UI — only the
subtitle was read for a static "Core focus: …" label, and
supplementToggles.core was dead state.

Add a "core" complement kind that reuses the existing SUPPLEMENT_EX
metadata for each core drill. The complement picker now renders a
"Core focus" section per training day populated from
SUPPLEMENT_CORE[workoutKey].exercises, labelled by region (Upper Abs /
Lower Abs / Obliques) and color-coded with the --color-core-sup
orange. Cards appear in the exercise row superset slot and in Focus
Mode alongside the existing cable / machine-variant / left-leg /
mobility supplements.

Persistence piggybacks on dayState.complements so opt-ins clear
daily — same as every other complement kind. Decoder keeps
backward compat with legacy colon-delimited IDs.

https://claude.ai/code/session_01MTqbbKWUN23KH8y1mBiTB7