### PR TITLE
Scaffold workout-log data model (types + localStorage helpers)

### DIFF
--- a/components/exercise-row.tsx
+++ b/components/exercise-row.tsx
@@ -1,11 +1,20 @@
 "use client";
 
 import React from "react";
+import dynamic from "next/dynamic";
 import Badge from "@/components/badge";
 import { Exercise, EQUIPMENT } from "@/lib/exercises";
+
+// Set tracker is a client-only component (touches localStorage on hydrate);
+// disabling SSR avoids a Turbopack chunk-init order issue when it's eagerly
+// imported into the SSR'd workout-view bundle.
+const SetTracker = dynamic(() => import("@/components/set-tracker"), {
+  ssr: false,
+});
 import { EXERCISE_TO_DIAGRAM } from "@/components/diagrams";
 import { useLongPress } from "@/lib/use-long-press";
 import { cssAlpha } from "@/lib/css-utils";
+import type { WorkoutLogHook } from "@/lib/use-workout-log";
 
 interface ExerciseRowProps {
   name: string;
@@ -21,6 +30,7 @@ interface ExerciseRowProps {
   equipment: Record<string, boolean>;
   variantSetupCues?: string[];
   variantLabel?: string;
+  variantId?: string;
   /**
    * Requires override from the active machine variant. When present it
    * replaces `ex.requires` for the equipment-chip display so the chips
@@ -31,6 +41,8 @@ interface ExerciseRowProps {
   addComplementSlot?: React.ReactNode;
   /** Small top-right action button (opens edit sheet). Hidden if omitted. */
   showActionButton?: boolean;
+  /** When provided, the in-app set tracker renders inside the expanded panel. */
+  log?: WorkoutLogHook;
 }
 
 export default function ExerciseRow({
@@ -47,9 +59,11 @@ export default function ExerciseRow({
   equipment,
   variantSetupCues,
   variantLabel,
+  variantId,
   variantRequires,
   addComplementSlot,
   showActionButton = true,
+  log,
 }: ExerciseRowProps) {
   const longPressHandlers = useLongPress(
     () => onLongPress?.(),
@@ -163,11 +177,11 @@ export default function ExerciseRow({
       {/* Expanded details */}
       {isExpanded && (
         <div className="section-content px-3.5 pb-4">
-          {/* Sets / Reps / Rest stats — first so it's the action-focused header */}
+          {/* Sets / Reps / Rest stats — prescribed target */}
           <div className="flex gap-4 mb-3 py-2.5 border-b border-border">
             <div>
               <div className="text-[10px] text-text-muted uppercase tracking-wider font-medium">
-                Sets &times; Reps
+                Target
               </div>
               <div className="text-base font-bold text-accent tabular-nums mt-0.5">
                 {s[0]} &times; {s[1]}
@@ -184,6 +198,19 @@ export default function ExerciseRow({
               </div>
             )}
           </div>
+
+          {/* In-app set tracker (live logging) */}
+          {log && (
+            <SetTracker
+              exerciseId={ex.id}
+              exerciseName={name}
+              variantId={variantId}
+              defaultRest={ex.rest}
+              prescribedReps={s[1]}
+              log={log}
+              onStartTimer={onStartTimer}
+            />
+          )}
 
           {/* Diagram buttons — directly under sets/reps for fastest access */}
           {EXERCISE_TO_DIAGRAM[ex.id] && (

--- a/components/session-bar.tsx
+++ b/components/session-bar.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import type { WorkoutLogHook } from "@/lib/use-workout-log";
+
+interface SessionBarProps {
+  log: WorkoutLogHook;
+  /** Workout label shown in the bar (e.g. "Push B"). */
+  workoutLabel: string;
+}
+
+/**
+ * Sticky top status bar for the active workout session.
+ *
+ * Renders only when there's an active session — invisible until the user
+ * logs their first set. Shows elapsed time live (1Hz tick), the workout
+ * name, set count, and a "Finish" button that archives the session.
+ */
+export default function SessionBar({ log, workoutLabel }: SessionBarProps) {
+  const { active, endWorkout, hydrated } = log;
+  const [now, setNow] = useState(() => Date.now());
+  const [confirming, setConfirming] = useState(false);
+
+  // Tick once a second to keep the elapsed-time readout live.
+  useEffect(() => {
+    if (!active) return;
+    const iv = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(iv);
+  }, [active]);
+
+  if (!hydrated || !active) return null;
+
+  const elapsedMs = Math.max(0, now - active.startedAt);
+  const totalSets = active.exercises.reduce((acc, e) => acc + e.sets.length, 0);
+
+  return (
+    <div
+      data-testid="session-bar"
+      className="sticky top-0 z-30 flex items-center gap-3 px-3 py-2 border-b border-border"
+      style={{
+        background: "var(--color-card)",
+        backdropFilter: "blur(8px)",
+      }}
+    >
+      <div
+        className="w-2 h-2 rounded-full flex-shrink-0"
+        style={{ background: "var(--color-safe)", boxShadow: "0 0 8px var(--color-safe)" }}
+        aria-hidden="true"
+      />
+
+      <div className="flex-1 min-w-0">
+        <div className="text-[10px] uppercase tracking-wider font-bold text-text-muted leading-tight">
+          {workoutLabel} &middot; {totalSets} {totalSets === 1 ? "set" : "sets"}
+        </div>
+        <div className="text-base font-bold tabular-nums text-text leading-tight">
+          {formatElapsed(elapsedMs)}
+        </div>
+      </div>
+
+      {confirming ? (
+        <div className="flex gap-1.5">
+          <button
+            data-testid="end-confirm"
+            onClick={() => {
+              endWorkout();
+              setConfirming(false);
+            }}
+            className="rounded-md px-3 py-1.5 text-[11px] font-bold uppercase tracking-wide"
+            style={{ background: "var(--color-safe)", color: "#000" }}
+          >
+            Finish
+          </button>
+          <button
+            onClick={() => setConfirming(false)}
+            className="rounded-md px-2 py-1.5 text-[11px] uppercase tracking-wide text-text-muted border border-border"
+          >
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <button
+          data-testid="end-workout"
+          onClick={() => setConfirming(true)}
+          className="rounded-md px-3 py-1.5 text-[11px] font-bold uppercase tracking-wide text-accent border border-border"
+          style={{ background: "var(--color-bg)" }}
+        >
+          End
+        </button>
+      )}
+    </div>
+  );
+}
+
+function formatElapsed(ms: number): string {
+  const total = Math.floor(ms / 1000);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  if (h > 0) {
+    return `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+  }
+  return `${m}:${String(s).padStart(2, "0")}`;
+}

--- a/components/set-tracker.tsx
+++ b/components/set-tracker.tsx
@@ -69,7 +69,7 @@ function NumStepper({
         value={value}
         onChange={(ev) => onChange(ev.target.value.replace(/[^0-9.]/g, ""))}
         placeholder={hint && hint.length > 0 ? hint : "0"}
-        className="flex-1 min-w-0 px-1 py-2 text-center text-base font-bold tabular-nums bg-transparent text-text placeholder:text-text-dim focus:outline-none"
+        className="flex-1 min-w-[48px] w-full px-1 py-2 text-center text-base font-bold tabular-nums bg-transparent text-text placeholder:text-text-dim focus:outline-none"
         style={{ color: value ? "var(--color-text)" : undefined }}
         aria-label={label}
       />
@@ -330,41 +330,50 @@ export default function SetTracker({
       ) : null}
 
       <div className="px-3 pb-3">
-        <div className="grid grid-cols-[auto_1fr_auto_1fr_auto] gap-2 items-center">
-          <span className="text-[11px] font-bold text-text-dim w-6 text-center tabular-nums">
+        <div className="flex items-center gap-2">
+          <span className="text-[11px] font-bold text-text-dim w-5 text-center tabular-nums shrink-0">
             {sets.length + 1}
           </span>
 
-          <NumStepper
-            value={draftWeight}
-            onChange={setDraftWeight}
-            onMinus={() => adjustWeight(-5)}
-            onPlus={() => adjustWeight(5)}
-            label="lbs"
-          />
+          <div className="flex-1 min-w-0">
+            <NumStepper
+              value={draftWeight}
+              onChange={setDraftWeight}
+              onMinus={() => adjustWeight(-5)}
+              onPlus={() => adjustWeight(5)}
+              label="lbs"
+            />
+          </div>
 
-          <span className="text-text-muted text-sm">×</span>
+          <span className="text-text-muted text-sm shrink-0">×</span>
 
-          <NumStepper
-            value={draftReps}
-            onChange={setDraftReps}
-            onMinus={() => adjustReps(-1)}
-            onPlus={() => adjustReps(1)}
-            label="reps"
-            hint={prescribedReps}
-          />
-
-          <button
-            onClick={handleLogSet}
-            disabled={!draftReps && !draftWeight}
-            data-testid="log-set"
-            className="min-w-[44px] min-h-[44px] rounded-lg flex items-center justify-center font-bold text-base disabled:opacity-40"
-            style={{ background: "var(--color-safe)", color: "#000" }}
-            aria-label="Log set"
-          >
-            ✓
-          </button>
+          <div className="flex-1 min-w-0">
+            <NumStepper
+              value={draftReps}
+              onChange={setDraftReps}
+              onMinus={() => adjustReps(-1)}
+              onPlus={() => adjustReps(1)}
+              label="reps"
+              hint={prescribedReps}
+            />
+          </div>
         </div>
+
+        <button
+          onClick={handleLogSet}
+          disabled={!draftReps && !draftWeight}
+          data-testid="log-set"
+          className="w-full mt-2 min-h-[44px] rounded-lg flex items-center justify-center gap-2 font-bold text-sm uppercase tracking-wide disabled:opacity-40"
+          style={{ background: "var(--color-safe)", color: "#000" }}
+          aria-label="Log set"
+        >
+          <span>✓</span>
+          <span>
+            Log set {draftWeight ? `${draftWeight}lb` : ""}
+            {draftWeight && draftReps ? " × " : ""}
+            {draftReps || ""}
+          </span>
+        </button>
 
         <input
           type="text"

--- a/components/set-tracker.tsx
+++ b/components/set-tracker.tsx
@@ -1,0 +1,382 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import {
+  type LoggedSet,
+  haptic,
+  loadEquipmentPhotos,
+  addEquipmentPhoto,
+} from "@/lib/workout-log";
+import type { WorkoutLogHook } from "@/lib/use-workout-log";
+
+// ── Helpers (declared before consumer to avoid any hoisting/TDZ surprises in
+//    bundlers that aggressively split client-component chunks). ──
+
+function formatWeight(w: number): string {
+  return w % 1 === 0 ? String(w) : w.toFixed(1);
+}
+
+function timeAgo(ts: number): string {
+  const diff = Date.now() - ts;
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return `${weeks}w ago`;
+  const months = Math.floor(days / 30);
+  return `${months}mo ago`;
+}
+
+function NumStepper({
+  value,
+  onChange,
+  onMinus,
+  onPlus,
+  label,
+  hint,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  onMinus: () => void;
+  onPlus: () => void;
+  label: string;
+  hint?: string;
+}) {
+  return (
+    <div className="flex items-stretch border border-border rounded-md overflow-hidden bg-bg">
+      <button
+        type="button"
+        onClick={onMinus}
+        className="px-2.5 text-text-muted text-base font-bold min-w-[36px] active:bg-card-hover"
+        aria-label={`Decrease ${label}`}
+      >
+        −
+      </button>
+      <input
+        type="number"
+        inputMode={label === "lbs" ? "decimal" : "numeric"}
+        value={value}
+        onChange={(ev) => onChange(ev.target.value)}
+        placeholder={hint ?? "0"}
+        className="flex-1 min-w-0 px-1 py-1.5 text-center text-[15px] font-bold tabular-nums bg-transparent text-text placeholder:text-text-muted focus:outline-none"
+        aria-label={label}
+      />
+      <button
+        type="button"
+        onClick={onPlus}
+        className="px-2.5 text-text-muted text-base font-bold min-w-[36px] active:bg-card-hover"
+        aria-label={`Increase ${label}`}
+      >
+        +
+      </button>
+    </div>
+  );
+}
+
+function LoggedRow({
+  set,
+  onRemove,
+  onEdit,
+}: {
+  set: LoggedSet;
+  onRemove: () => void;
+  onEdit: (patch: Partial<LoggedSet>) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [w, setW] = useState(() => String(set.weight || ""));
+  const [r, setR] = useState(() => String(set.reps || ""));
+
+  if (editing) {
+    return (
+      <div className="grid grid-cols-[auto_1fr_auto_1fr_auto_auto] gap-2 items-center">
+        <span className="text-[11px] font-bold text-text-muted w-6 text-center tabular-nums">
+          {set.n}
+        </span>
+        <input
+          type="number"
+          inputMode="decimal"
+          value={w}
+          onChange={(e) => setW(e.target.value)}
+          className="w-full px-2 py-1 text-sm rounded-md bg-bg border border-accent text-text tabular-nums"
+        />
+        <span className="text-text-muted text-xs">×</span>
+        <input
+          type="number"
+          inputMode="numeric"
+          value={r}
+          onChange={(e) => setR(e.target.value)}
+          className="w-full px-2 py-1 text-sm rounded-md bg-bg border border-accent text-text tabular-nums"
+        />
+        <button
+          onClick={() => {
+            onEdit({
+              weight: parseFloat(w) || 0,
+              reps: parseInt(r, 10) || 0,
+            });
+            setEditing(false);
+          }}
+          className="text-accent font-bold text-base px-2"
+          aria-label="Save edit"
+        >
+          ✓
+        </button>
+        <button
+          onClick={() => setEditing(false)}
+          className="text-text-muted text-base px-2"
+          aria-label="Cancel edit"
+        >
+          ✕
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="logged-set"
+      className="grid grid-cols-[auto_1fr_auto] gap-2 items-center text-sm"
+      style={{ color: "var(--color-text)" }}
+    >
+      <span
+        className="text-[11px] font-bold w-6 text-center tabular-nums"
+        style={{ color: "var(--color-safe)" }}
+      >
+        ✓{set.n}
+      </span>
+      <button
+        onClick={() => setEditing(true)}
+        className="text-left tabular-nums hover:underline decoration-dotted"
+        aria-label="Edit set"
+      >
+        {set.weight ? `${formatWeight(set.weight)}lb × ` : ""}
+        {set.reps}{set.durationSec ? `s` : ""}
+        {set.note ? <span className="text-text-muted text-xs"> — {set.note}</span> : null}
+      </button>
+      <button
+        onClick={onRemove}
+        className="text-text-muted text-xs px-2 py-1"
+        aria-label="Remove set"
+        title="Remove set"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}
+
+function PhotoButton({ exerciseId }: { exerciseId: string }) {
+  const [count, setCount] = useState(0);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    setCount(loadEquipmentPhotos().filter((p) => p.exerciseId === exerciseId).length);
+  }, [exerciseId]);
+
+  const onPick = (ev: React.ChangeEvent<HTMLInputElement>) => {
+    const file = ev.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        const next = addEquipmentPhoto(exerciseId, reader.result);
+        setCount(next.filter((p) => p.exerciseId === exerciseId).length);
+      }
+    };
+    reader.readAsDataURL(file);
+    ev.target.value = "";
+  };
+
+  return (
+    <label
+      className="flex items-center gap-1 px-2.5 py-1.5 text-[12px] rounded-md border border-border bg-bg text-text-dim cursor-pointer active:bg-card-hover"
+      title="Photograph the equipment you used"
+    >
+      📷
+      {count > 0 && <span className="text-[10px] font-bold text-accent">{count}</span>}
+      <input type="file" accept="image/*" capture="environment" onChange={onPick} className="hidden" />
+    </label>
+  );
+}
+
+// ── Main component ──
+
+interface SetTrackerProps {
+  exerciseId: string;
+  exerciseName: string;
+  variantId?: string;
+  /** Default rest seconds from the exercise definition. */
+  defaultRest: number;
+  /** Prescribed reps (e.g. "8-10") for the current phase — used as a hint. */
+  prescribedReps?: string;
+  log: WorkoutLogHook;
+  /** Triggers the global RestTimer with the given seconds. */
+  onStartTimer?: (seconds: number) => void;
+}
+
+/**
+ * Inline set-tracker rendered inside an expanded ExerciseRow.
+ *
+ * Tap ✓ to commit a set → fires haptic, starts the rest timer, opens a fresh
+ * pending row prefilled from the just-logged set. Logged rows are tap-to-edit
+ * or ✕-to-remove. Per-set notes for vague freestyle ("RPE", "neutral grip",
+ * pain notes). Per-exercise note + a photo button (caches base64 in
+ * localStorage under `equipment-photos`).
+ */
+export default function SetTracker({
+  exerciseId,
+  exerciseName,
+  variantId,
+  defaultRest,
+  prescribedReps,
+  log,
+  onStartTimer,
+}: SetTrackerProps) {
+  const logged = log.loggedFor(exerciseId);
+  const sets = logged?.sets ?? [];
+  const lastEver = log.lastSet(exerciseId);
+
+  // Pending-set draft state. Prefill chain:
+  // 1. last set in today's session (if any), else
+  // 2. last set across history, else
+  // 3. blank — let user type.
+  const seed = sets.length > 0 ? sets[sets.length - 1] : lastEver;
+  const seedWeight = seed?.weight ?? 0;
+  const seedReps = seed?.reps ?? 0;
+
+  const [draftWeight, setDraftWeight] = useState<string>(() =>
+    seedWeight ? String(seedWeight) : "",
+  );
+  const [draftReps, setDraftReps] = useState<string>(() =>
+    seedReps ? String(seedReps) : "",
+  );
+  const [draftNote, setDraftNote] = useState("");
+
+  // Re-seed inputs after a set is committed (the seed values change because
+  // sets[] grew). Don't depend on the user's typed-in state — driven only by
+  // the underlying seed numbers.
+  useEffect(() => {
+    setDraftWeight(seedWeight ? String(seedWeight) : "");
+    setDraftReps(seedReps ? String(seedReps) : "");
+  }, [seedWeight, seedReps]);
+
+  const [exerciseNote, setExerciseNoteState] = useState(logged?.note ?? "");
+  useEffect(() => {
+    setExerciseNoteState(logged?.note ?? "");
+  }, [logged?.note]);
+
+  const handleLogSet = () => {
+    const weight = parseFloat(draftWeight) || 0;
+    const reps = parseInt(draftReps, 10) || 0;
+    log.logSet(
+      exerciseId,
+      exerciseName,
+      { weight, reps, note: draftNote || undefined },
+      variantId,
+    );
+    setDraftNote("");
+    haptic(35);
+    if (defaultRest > 0) onStartTimer?.(defaultRest);
+  };
+
+  const adjustWeight = (delta: number) => {
+    const cur = parseFloat(draftWeight) || 0;
+    const next = Math.max(0, cur + delta);
+    setDraftWeight(next % 1 === 0 ? String(next) : next.toFixed(1));
+  };
+  const adjustReps = (delta: number) => {
+    const cur = parseInt(draftReps, 10) || 0;
+    const next = Math.max(0, cur + delta);
+    setDraftReps(String(next));
+  };
+
+  return (
+    <div className="rounded-xl border border-border bg-card mb-3 overflow-hidden">
+      <div className="px-3 pt-2.5 pb-2 flex items-center justify-between text-[10px] uppercase tracking-wider font-bold text-text-muted">
+        <span>Today's sets</span>
+        {lastEver ? (
+          <span className="normal-case tracking-normal text-text-dim">
+            Last: {lastEver.weight ? `${formatWeight(lastEver.weight)}lb × ` : ""}
+            {lastEver.reps}
+            {lastEver.completedAt ? <> &middot; {timeAgo(lastEver.completedAt)}</> : null}
+          </span>
+        ) : null}
+      </div>
+
+      {sets.length > 0 ? (
+        <div className="px-3 pb-2 space-y-1.5">
+          {sets.map((s) => (
+            <LoggedRow
+              key={s.n}
+              set={s}
+              onRemove={() => log.removeSet(exerciseId, s.n)}
+              onEdit={(patch) => log.editSet(exerciseId, s.n, patch)}
+            />
+          ))}
+        </div>
+      ) : null}
+
+      <div className="px-3 pb-3">
+        <div className="grid grid-cols-[auto_1fr_auto_1fr_auto] gap-2 items-center">
+          <span className="text-[11px] font-bold text-text-dim w-6 text-center tabular-nums">
+            {sets.length + 1}
+          </span>
+
+          <NumStepper
+            value={draftWeight}
+            onChange={setDraftWeight}
+            onMinus={() => adjustWeight(-5)}
+            onPlus={() => adjustWeight(5)}
+            label="lbs"
+          />
+
+          <span className="text-text-muted text-sm">×</span>
+
+          <NumStepper
+            value={draftReps}
+            onChange={setDraftReps}
+            onMinus={() => adjustReps(-1)}
+            onPlus={() => adjustReps(1)}
+            label="reps"
+            hint={prescribedReps}
+          />
+
+          <button
+            onClick={handleLogSet}
+            disabled={!draftReps && !draftWeight}
+            data-testid="log-set"
+            className="min-w-[44px] min-h-[44px] rounded-lg flex items-center justify-center font-bold text-base disabled:opacity-40"
+            style={{ background: "var(--color-safe)", color: "#000" }}
+            aria-label="Log set"
+          >
+            ✓
+          </button>
+        </div>
+
+        <input
+          type="text"
+          value={draftNote}
+          onChange={(ev) => setDraftNote(ev.target.value)}
+          placeholder="Note for this set (RPE, grip, pain, etc.)"
+          className="w-full mt-2 px-2.5 py-1.5 text-[12px] rounded-md bg-bg border border-border text-text-dim placeholder:text-text-muted focus:outline-none focus:border-accent"
+        />
+      </div>
+
+      <div className="border-t border-border px-3 py-2.5 flex gap-2 items-stretch">
+        <input
+          type="text"
+          value={exerciseNote}
+          onChange={(ev) => setExerciseNoteState(ev.target.value)}
+          onBlur={() =>
+            log.setExerciseNote(exerciseId, exerciseName, exerciseNote, variantId)
+          }
+          placeholder="Exercise note (custom variation, machine #, etc.)"
+          className="flex-1 px-2.5 py-1.5 text-[12px] rounded-md bg-bg border border-border text-text-dim placeholder:text-text-muted focus:outline-none focus:border-accent"
+        />
+        <PhotoButton exerciseId={exerciseId} />
+      </div>
+    </div>
+  );
+}

--- a/components/set-tracker.tsx
+++ b/components/set-tracker.tsx
@@ -16,6 +16,12 @@ function formatWeight(w: number): string {
   return w % 1 === 0 ? String(w) : w.toFixed(1);
 }
 
+function parsePrescribedLow(prescribed?: string): number | null {
+  if (!prescribed) return null;
+  const m = prescribed.match(/(\d+)/);
+  return m ? parseInt(m[1], 10) : null;
+}
+
 function timeAgo(ts: number): string {
   const diff = Date.now() - ts;
   const minutes = Math.floor(diff / 60000);
@@ -51,24 +57,26 @@ function NumStepper({
       <button
         type="button"
         onClick={onMinus}
-        className="px-2.5 text-text-muted text-base font-bold min-w-[36px] active:bg-card-hover"
+        className="px-2 text-text-dim text-lg font-bold min-w-[32px] active:bg-card-hover"
         aria-label={`Decrease ${label}`}
       >
         −
       </button>
       <input
-        type="number"
+        type="text"
         inputMode={label === "lbs" ? "decimal" : "numeric"}
+        pattern="[0-9.]*"
         value={value}
-        onChange={(ev) => onChange(ev.target.value)}
-        placeholder={hint ?? "0"}
-        className="flex-1 min-w-0 px-1 py-1.5 text-center text-[15px] font-bold tabular-nums bg-transparent text-text placeholder:text-text-muted focus:outline-none"
+        onChange={(ev) => onChange(ev.target.value.replace(/[^0-9.]/g, ""))}
+        placeholder={hint && hint.length > 0 ? hint : "0"}
+        className="flex-1 min-w-0 px-1 py-2 text-center text-base font-bold tabular-nums bg-transparent text-text placeholder:text-text-dim focus:outline-none"
+        style={{ color: value ? "var(--color-text)" : undefined }}
         aria-label={label}
       />
       <button
         type="button"
         onClick={onPlus}
-        className="px-2.5 text-text-muted text-base font-bold min-w-[36px] active:bg-card-hover"
+        className="px-2 text-text-dim text-lg font-bold min-w-[32px] active:bg-card-hover"
         aria-label={`Increase ${label}`}
       >
         +
@@ -244,7 +252,10 @@ export default function SetTracker({
   // 3. blank — let user type.
   const seed = sets.length > 0 ? sets[sets.length - 1] : lastEver;
   const seedWeight = seed?.weight ?? 0;
-  const seedReps = seed?.reps ?? 0;
+  // Prefill reps: prefer last logged, else low end of prescribed range
+  // ("5-6" → 5, "8" → 8) so user just adjusts ± rather than typing from blank.
+  const prescribedLow = parsePrescribedLow(prescribedReps);
+  const seedReps = seed?.reps ?? prescribedLow ?? 0;
 
   const [draftWeight, setDraftWeight] = useState<string>(() =>
     seedWeight ? String(seedWeight) : "",

--- a/components/set-tracker.tsx
+++ b/components/set-tracker.tsx
@@ -331,10 +331,6 @@ export default function SetTracker({
 
       <div className="px-3 pb-3">
         <div className="flex items-center gap-2">
-          <span className="text-[11px] font-bold text-text-dim w-5 text-center tabular-nums shrink-0">
-            {sets.length + 1}
-          </span>
-
           <div className="flex-1 min-w-0">
             <NumStepper
               value={draftWeight}

--- a/components/workout-view.tsx
+++ b/components/workout-view.tsx
@@ -33,6 +33,8 @@ import DiagramGallery from "@/components/diagrams/gallery";
 import { EXERCISE_TO_DIAGRAM, EXERCISES as DIAGRAM_EXERCISES } from "@/components/diagrams";
 import EditExerciseSheet from "@/components/edit-exercise-sheet";
 import AddExercisePicker from "@/components/add-exercise-picker";
+import SessionBar from "@/components/session-bar";
+import { useWorkoutLog } from "@/lib/use-workout-log";
 import ComplementPicker, {
   decodeComplement,
   encodeNearbyId,
@@ -1231,6 +1233,8 @@ export default function WorkoutView() {
           variantSetupCues={selectedVariant?.setupCues}
           variantLabel={selectedVariant?.label}
           variantRequires={selectedVariant?.requires}
+          variantId={selectedVariant?.id}
+          log={log}
           addComplementSlot={buildAddComplementPill(name, ex)}
         />
         {buildSupersetCards(name, ex, "__core__", null)}
@@ -1515,6 +1519,8 @@ export default function WorkoutView() {
                 variantSetupCues={selectedVariant?.setupCues}
                 variantLabel={selectedVariant?.label}
                 variantRequires={selectedVariant?.requires}
+                variantId={selectedVariant?.id}
+                log={log}
                 addComplementSlot={buildAddComplementPill(exName, ex, workoutKey)}
               />
               {buildSupersetCards(exName, ex, workoutKey, firstCableName)}
@@ -1589,6 +1595,8 @@ export default function WorkoutView() {
                     variantSetupCues={selectedVariant?.setupCues}
                     variantLabel={selectedVariant?.label}
                     variantRequires={selectedVariant?.requires}
+                    variantId={selectedVariant?.id}
+                    log={log}
                     addComplementSlot={buildAddComplementPill(name, ex)}
                   />
                   {buildSupersetCards(name, ex, "__finisher__", null)}
@@ -1940,6 +1948,8 @@ export default function WorkoutView() {
                   variantSetupCues={selectedVariant?.setupCues}
                   variantLabel={selectedVariant?.label}
                   variantRequires={selectedVariant?.requires}
+                  variantId={selectedVariant?.id}
+                  log={log}
                   addComplementSlot={buildAddComplementPill(k, ex)}
                 />
                 {buildSupersetCards(k, ex, "__cardio__", null)}
@@ -2708,6 +2718,13 @@ export default function WorkoutView() {
     );
   }
 
+  // ===== ACTIVE WORKOUT-LOG SESSION =====
+  // Must be declared BEFORE the render-tab switch — renderTodayTab() and
+  // renderWorkout() iterate exercises and pass `log` into ExerciseRow as a
+  // prop, so the const has to be initialised before those functions execute.
+  const todayWorkoutKey = getWorkoutForDay(selectedDay).t;
+  const log = useWorkoutLog(todayWorkoutKey);
+
   // ===== RENDER ACTIVE TAB =====
   let content: React.ReactNode = null;
   switch (tab) {
@@ -2739,6 +2756,8 @@ export default function WorkoutView() {
   // ===== MAIN LAYOUT =====
   return (
     <div data-testid="app-container" className="app-container max-w-[600px] mx-auto px-4 pb-24 min-h-screen bg-bg">
+      <SessionBar log={log} workoutLabel={log.active?.workoutKey ?? todayWorkoutKey} />
+
       {/* Header */}
       <div className="pt-8 pb-5 text-center">
         <div className="flex items-center justify-center gap-2.5">

--- a/e2e/test_set_tracker.py
+++ b/e2e/test_set_tracker.py
@@ -1,0 +1,378 @@
+"""In-app set tracker E2E tests.
+
+Covers logging, edit/remove, auto rest timer, persistence, stale-session
+auto-archive, per-set notes, and equipment photos. The tracker is rendered
+inside the expanded ExerciseRow on the Today tab.
+"""
+
+import base64
+import time
+
+from playwright.sync_api import Page, expect
+
+from conftest import click_tab, get_local_storage, set_local_storage
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+ACTIVE_KEY = "workout-log:active"
+SESSIONS_KEY = "workout-log:sessions"
+PHOTOS_KEY = "equipment-photos"
+
+
+def _seed_deterministic_day(page: Page, base_url: str):
+    """Seed startDay=Mon and rest day=Sun, then click Monday in the day picker
+    so we reliably land on a training day (Push A) regardless of real-life
+    today. Returns after first section + first exercise are expanded.
+    """
+    # Default schedule: startDay=0 (Mon), restDay=6 (Sun) → Mon=Push A.
+    set_local_storage(page, {"nwb_startDay": 0, "nwb_restDay": 6})
+    page.reload()
+    page.wait_for_selector("[data-testid='app-container']")
+
+    click_tab(page, "workout")
+    page.wait_for_timeout(200)
+
+    content = page.get_by_test_id("tab-content")
+    # Click Monday cell (index 0) to deterministically pick Push A.
+    day_cells = content.locator(".grid.grid-cols-7 > div")
+    day_cells.nth(0).click()
+    page.wait_for_timeout(300)
+
+
+def _expand_first_exercise(page: Page):
+    """Expand first section, then first exercise row. Returns the row locator."""
+    sections = page.get_by_test_id("tab-content").get_by_test_id("section")
+    assert sections.count() > 0, "Expected at least one workout section"
+
+    # Sections may or may not auto-open from the day-pick toggle; click header
+    # button to ensure expanded state.
+    section = sections.first
+    # If no exercise rows visible, click section header to expand
+    if section.get_by_test_id("exercise-row").count() == 0:
+        section.locator("button").first.click()
+        page.wait_for_timeout(300)
+
+    rows = section.get_by_test_id("exercise-row")
+    assert rows.count() > 0, "Expected at least one exercise row"
+
+    row = rows.first
+    # Click header to expand the detail panel (which renders SetTracker)
+    row.get_by_test_id("exercise-row-header").click()
+    page.wait_for_timeout(400)
+    return row
+
+
+def _set_tracker(row):
+    """Locator for the SetTracker block (no testid; we scope via ✓ button parent)."""
+    return row.get_by_test_id("log-set").locator("xpath=ancestor::div[contains(@class,'rounded-xl')][1]")
+
+
+def _type_weight_reps(row, weight: str, reps: str):
+    """Fill the pending-set inputs (weight + reps).
+
+    NumStepper renders <input type=number aria-label="lbs"> and
+    aria-label="reps". We target by aria-label to avoid relying on order.
+    """
+    weight_input = row.get_by_label("lbs", exact=True)
+    reps_input = row.get_by_label("reps", exact=True)
+    weight_input.fill(weight)
+    reps_input.fill(reps)
+
+
+def _commit_set(row):
+    row.get_by_test_id("log-set").click()
+
+
+def _logged_rows(row):
+    return row.get_by_test_id("logged-set")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_log_single_set(app_page: Page, base_url: str):
+    """Logging one set: row appears, SessionBar shows '1 set', RestTimer pops."""
+    _seed_deterministic_day(app_page, base_url)
+    row = _expand_first_exercise(app_page)
+
+    # Initially no SessionBar (no set logged yet).
+    expect(app_page.get_by_test_id("session-bar")).to_have_count(0)
+
+    _type_weight_reps(row, "135", "8")
+    _commit_set(row)
+    app_page.wait_for_timeout(400)
+
+    # (a) Logged row appears with the values.
+    rows = _logged_rows(row)
+    expect(rows).to_have_count(1)
+    txt = rows.first.inner_text()
+    assert "135" in txt and "8" in txt, f"Expected '135' and '8' in logged row, got: {txt}"
+
+    # (b) SessionBar visible with elapsed timer + '1 set'.
+    bar = app_page.get_by_test_id("session-bar")
+    expect(bar).to_be_visible()
+    bar_text = bar.inner_text()
+    assert "1 set" in bar_text.lower(), f"Expected '1 set' in bar text, got: {bar_text}"
+
+    # (c) RestTimer pops up. Default rest is the exercise's `rest` seconds (>0).
+    timer = app_page.get_by_test_id("rest-timer")
+    expect(timer).to_be_visible()
+    display = app_page.get_by_test_id("timer-display").inner_text()
+    # Display format like "M:SS" or similar — just confirm it has at least one digit.
+    assert any(ch.isdigit() for ch in display), f"Timer display should have digits, got: {display}"
+
+
+def test_autofill_from_prior_set(app_page: Page, base_url: str):
+    """Logging a set prefills the next pending row's inputs with same w × r."""
+    _seed_deterministic_day(app_page, base_url)
+    row = _expand_first_exercise(app_page)
+
+    _type_weight_reps(row, "95", "10")
+    _commit_set(row)
+    app_page.wait_for_timeout(400)
+
+    # Close any rest timer overlay so it doesn't intercept clicks.
+    if app_page.get_by_test_id("timer-close").count() > 0:
+        app_page.get_by_test_id("timer-close").click()
+        app_page.wait_for_timeout(200)
+
+    # The (now next) pending row should be prefilled with 95 / 10.
+    weight_val = row.get_by_label("lbs", exact=True).input_value()
+    reps_val = row.get_by_label("reps", exact=True).input_value()
+    assert weight_val == "95", f"Expected weight prefill '95', got '{weight_val}'"
+    assert reps_val == "10", f"Expected reps prefill '10', got '{reps_val}'"
+
+
+def test_edit_logged_set(app_page: Page, base_url: str):
+    """Tapping a logged row enters edit mode; ✓ persists the change."""
+    _seed_deterministic_day(app_page, base_url)
+    row = _expand_first_exercise(app_page)
+
+    _type_weight_reps(row, "135", "8")
+    _commit_set(row)
+    app_page.wait_for_timeout(400)
+    if app_page.get_by_test_id("timer-close").count() > 0:
+        app_page.get_by_test_id("timer-close").click()
+        app_page.wait_for_timeout(200)
+
+    logged = _logged_rows(row).first
+    # Tap the "Edit set" button (the value display). When the row enters edit
+    # mode, it re-renders WITHOUT data-testid="logged-set", so we have to
+    # query the editor inputs/buttons via the parent SetTracker block.
+    logged.get_by_role("button", name="Edit set").click()
+    app_page.wait_for_timeout(300)
+
+    # Save-edit button has aria-label="Save edit"; the two number inputs
+    # adjacent to it are weight + reps. Scope to the exercise row to avoid
+    # collisions with other trackers that might be on screen.
+    save_btn = row.get_by_role("button", name="Save edit")
+    expect(save_btn).to_be_visible()
+    # The two edit-mode inputs sit just above the pending-set's NumSteppers.
+    # The cleanest way to grab them is by aria-label difference: edit inputs
+    # have NO aria-label, while pending NumStepper inputs have label "lbs"
+    # and "reps". So filter to inputs without aria-label.
+    edit_inputs = row.locator("input[type=number]:not([aria-label])")
+    assert edit_inputs.count() == 2, \
+        f"Expected 2 unlabeled number inputs in edit mode, got {edit_inputs.count()}"
+    edit_inputs.nth(1).fill("12")
+    save_btn.click()
+    app_page.wait_for_timeout(300)
+
+    # Logged row text should now contain "12"
+    new_txt = _logged_rows(row).first.inner_text()
+    assert "12" in new_txt, f"Edit didn't persist; row text: {new_txt}"
+
+    # localStorage should reflect the change
+    active = get_local_storage(app_page, ACTIVE_KEY)
+    assert active is not None
+    sets = active["exercises"][0]["sets"]
+    assert sets[0]["reps"] == 12, f"Expected reps=12 in storage, got {sets[0]['reps']}"
+
+
+def test_remove_logged_set(app_page: Page, base_url: str):
+    """✕ on a logged row removes it; remaining sets renumber."""
+    _seed_deterministic_day(app_page, base_url)
+    row = _expand_first_exercise(app_page)
+
+    # Log 3 sets in a row.
+    for w, r in [("100", "10"), ("105", "8"), ("110", "6")]:
+        _type_weight_reps(row, w, r)
+        _commit_set(row)
+        app_page.wait_for_timeout(300)
+        if app_page.get_by_test_id("timer-close").count() > 0:
+            app_page.get_by_test_id("timer-close").click()
+            app_page.wait_for_timeout(150)
+
+    rows = _logged_rows(row)
+    expect(rows).to_have_count(3)
+
+    # Remove the middle set (index 1).
+    rows.nth(1).get_by_role("button", name="Remove set").click()
+    app_page.wait_for_timeout(300)
+
+    rows = _logged_rows(row)
+    expect(rows).to_have_count(2)
+
+    # Storage should have 2 sets, renumbered 1..2.
+    active = get_local_storage(app_page, ACTIVE_KEY)
+    sets = active["exercises"][0]["sets"]
+    assert len(sets) == 2
+    assert [s["n"] for s in sets] == [1, 2], f"Set numbers not renumbered: {[s['n'] for s in sets]}"
+    # Removed-middle: should keep 1st (100x10) and 3rd (110x6) — not 105x8.
+    weights = sorted(s["weight"] for s in sets)
+    assert 105 not in weights, f"Removed set's weight (105) still in: {weights}"
+
+
+def test_end_workout_archives(app_page: Page, base_url: str):
+    """End → Finish archives the session into workout-log:sessions."""
+    _seed_deterministic_day(app_page, base_url)
+    row = _expand_first_exercise(app_page)
+
+    _type_weight_reps(row, "115", "5")
+    _commit_set(row)
+    app_page.wait_for_timeout(400)
+    if app_page.get_by_test_id("timer-close").count() > 0:
+        app_page.get_by_test_id("timer-close").click()
+        app_page.wait_for_timeout(200)
+
+    bar = app_page.get_by_test_id("session-bar")
+    expect(bar).to_be_visible()
+
+    bar.get_by_test_id("end-workout").click()
+    app_page.wait_for_timeout(150)
+    bar.get_by_test_id("end-confirm").click()
+    app_page.wait_for_timeout(400)
+
+    # SessionBar disappears
+    expect(app_page.get_by_test_id("session-bar")).to_have_count(0)
+
+    # Active session cleared, archived sessions has 1 entry with our set.
+    active = get_local_storage(app_page, ACTIVE_KEY)
+    assert active is None, f"Active session should be null, got: {active}"
+
+    sessions = get_local_storage(app_page, SESSIONS_KEY)
+    assert isinstance(sessions, list) and len(sessions) >= 1, \
+        f"Expected at least 1 archived session, got: {sessions}"
+    last = sessions[-1]
+    assert last.get("endedAt"), "Archived session should have endedAt"
+    sets = last["exercises"][0]["sets"]
+    assert sets[0]["weight"] == 115 and sets[0]["reps"] == 5
+
+
+def test_persistence_across_reload(app_page: Page, base_url: str):
+    """Logged set survives a hard reload."""
+    _seed_deterministic_day(app_page, base_url)
+    row = _expand_first_exercise(app_page)
+
+    _type_weight_reps(row, "145", "7")
+    _commit_set(row)
+    app_page.wait_for_timeout(400)
+
+    # Snapshot what's in localStorage before reload.
+    pre = get_local_storage(app_page, ACTIVE_KEY)
+    assert pre is not None
+    pre_set = pre["exercises"][0]["sets"][0]
+    assert pre_set["weight"] == 145 and pre_set["reps"] == 7
+
+    # Hard reload.
+    app_page.reload()
+    app_page.wait_for_selector("[data-testid='app-container']")
+
+    # SessionBar should still be visible (active session restored).
+    expect(app_page.get_by_test_id("session-bar")).to_be_visible()
+
+    # Storage round-trips.
+    post = get_local_storage(app_page, ACTIVE_KEY)
+    assert post is not None
+    assert post["id"] == pre["id"], "Session id should match across reload"
+    assert post["exercises"][0]["sets"][0]["weight"] == 145
+    assert post["exercises"][0]["sets"][0]["reps"] == 7
+
+
+def test_stale_session_auto_archives(app_page: Page, base_url: str):
+    """An active session idle >4 hrs is auto-archived on app load."""
+    # Pre-seed an "old" active session — startedAt 5 hours ago, no sets.
+    five_hours_ago = int(time.time() * 1000) - 5 * 60 * 60 * 1000
+    stale = {
+        "id": "s-stale-test",
+        "workoutKey": "Push A",
+        "startedAt": five_hours_ago,
+        "exercises": [],
+    }
+    # Use raw setItem because conftest set_local_storage JSON-encodes again,
+    # but our value is already a dict — that's fine, set_local_storage
+    # JSON.stringifies it, which is what the app expects.
+    set_local_storage(app_page, {ACTIVE_KEY: stale, SESSIONS_KEY: []})
+    app_page.reload()
+    app_page.wait_for_selector("[data-testid='app-container']")
+    # Give the hook's mount effect a beat.
+    app_page.wait_for_timeout(400)
+
+    # SessionBar should NOT render (active was cleared).
+    expect(app_page.get_by_test_id("session-bar")).to_have_count(0)
+
+    # Active should be null, archived sessions should now contain the stale one.
+    assert get_local_storage(app_page, ACTIVE_KEY) is None
+    sessions = get_local_storage(app_page, SESSIONS_KEY)
+    assert isinstance(sessions, list) and len(sessions) >= 1
+    assert any(s.get("id") == "s-stale-test" for s in sessions), \
+        f"Stale session not in archived list: {sessions}"
+
+
+def test_per_set_note_renders(app_page: Page, base_url: str):
+    """A per-set note typed before ✓ shows up inline on the logged row."""
+    _seed_deterministic_day(app_page, base_url)
+    row = _expand_first_exercise(app_page)
+
+    _type_weight_reps(row, "120", "6")
+
+    # The note input is the first text input inside the tracker
+    # (placeholder "Note for this set...").
+    note_input = row.locator("input[placeholder*='Note for this set']")
+    note_input.fill("RPE 8 neutral grip")
+
+    _commit_set(row)
+    app_page.wait_for_timeout(400)
+
+    logged = _logged_rows(row).first
+    txt = logged.inner_text()
+    assert "RPE 8" in txt, f"Note not rendered inline; row text: {txt}"
+
+    # Storage check
+    active = get_local_storage(app_page, ACTIVE_KEY)
+    assert active["exercises"][0]["sets"][0]["note"] == "RPE 8 neutral grip"
+
+
+def test_equipment_photo_upload(app_page: Page, base_url: str, tmp_path):
+    """Uploading a tiny PNG bumps the count badge and writes to localStorage."""
+    _seed_deterministic_day(app_page, base_url)
+    row = _expand_first_exercise(app_page)
+
+    # Smallest valid 1x1 transparent PNG.
+    png_bytes = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    )
+    fixture = tmp_path / "equip.png"
+    fixture.write_bytes(png_bytes)
+
+    # The PhotoButton hides its <input type="file"> inside a label. Target it
+    # by its accept attribute since there's no testid.
+    file_input = row.locator("input[type=file][accept='image/*']")
+    assert file_input.count() == 1, \
+        f"Expected exactly 1 photo file input, got {file_input.count()}"
+    file_input.set_input_files(str(fixture))
+    app_page.wait_for_timeout(500)  # FileReader is async
+
+    # Storage should have an equipment-photos entry for this exercise.
+    photos = get_local_storage(app_page, PHOTOS_KEY)
+    assert isinstance(photos, list) and len(photos) == 1, \
+        f"Expected 1 photo in storage, got: {photos}"
+    p = photos[0]
+    assert isinstance(p.get("exerciseId"), str) and len(p["exerciseId"]) > 0
+    assert p["dataUrl"].startswith("data:image/"), \
+        f"Photo dataUrl should be a data URL, got: {p.get('dataUrl', '')[:40]}"
+    assert isinstance(p.get("capturedAt"), int) and p["capturedAt"] > 0

--- a/lib/use-workout-log.ts
+++ b/lib/use-workout-log.ts
@@ -1,0 +1,187 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  type LoggedSet,
+  type LoggedExercise,
+  type WorkoutSession,
+  loadActiveSession,
+  saveActiveSession,
+  loadSessions,
+  saveSessions,
+  startSession,
+  endSession,
+  getOrCreateLoggedExercise,
+  isSessionStale,
+  lastSetFor,
+} from "./workout-log";
+
+/**
+ * React hook for the active set-logging session. Handles localStorage
+ * hydration, stale-session cleanup, and exposes mutators that auto-persist.
+ *
+ * Singleton-ish: every call mutates the same localStorage keys, so opening
+ * the hook in two places stays consistent across remounts (the state drift
+ * within a single render tree is avoided by always re-reading on mount).
+ */
+export function useWorkoutLog(currentWorkoutKey: string) {
+  const [active, setActive] = useState<WorkoutSession | null>(null);
+  const [history, setHistory] = useState<WorkoutSession[]>([]);
+  const [hydrated, setHydrated] = useState(false);
+
+  // Hydrate from localStorage on mount.
+  useEffect(() => {
+    const a = loadActiveSession();
+    const h = loadSessions();
+    setHistory(h);
+    if (a && isSessionStale(a)) {
+      // Auto-archive a stale session (>4hr idle) so we don't accidentally
+      // append today's sets to yesterday's workout.
+      endSession(a);
+      setHistory(loadSessions());
+      setActive(null);
+    } else {
+      setActive(a);
+    }
+    setHydrated(true);
+  }, []);
+
+  // Persist active whenever it changes (post-hydration only).
+  useEffect(() => {
+    if (!hydrated) return;
+    saveActiveSession(active);
+  }, [active, hydrated]);
+
+  /** Ensure an active session exists. Creates one targeted at currentWorkoutKey if missing. */
+  const ensureActive = useCallback((): WorkoutSession => {
+    if (active) return active;
+    const fresh = startSession(currentWorkoutKey);
+    setActive(fresh);
+    return fresh;
+  }, [active, currentWorkoutKey]);
+
+  /** Log a new set for an exercise. Returns the updated set. */
+  const logSet = useCallback(
+    (
+      exerciseId: string,
+      name: string,
+      set: Omit<LoggedSet, "n" | "completedAt">,
+      variantId?: string,
+    ): LoggedSet => {
+      // Snapshot first so we mutate a fresh copy.
+      const session = active ?? startSession(currentWorkoutKey);
+      const next: WorkoutSession = {
+        ...session,
+        exercises: session.exercises.map((e) => ({ ...e, sets: [...e.sets] })),
+      };
+      const entry = getOrCreateLoggedExercise(next, exerciseId, name, variantId);
+      const newSet: LoggedSet = {
+        ...set,
+        n: entry.sets.length + 1,
+        completedAt: Date.now(),
+      };
+      entry.sets.push(newSet);
+      setActive(next);
+      return newSet;
+    },
+    [active, currentWorkoutKey],
+  );
+
+  /** Update a previously logged set in place (edit reps/weight/note). */
+  const editSet = useCallback(
+    (exerciseId: string, n: number, patch: Partial<LoggedSet>) => {
+      if (!active) return;
+      const next: WorkoutSession = {
+        ...active,
+        exercises: active.exercises.map((e) =>
+          e.exerciseId === exerciseId
+            ? {
+                ...e,
+                sets: e.sets.map((s) => (s.n === n ? { ...s, ...patch } : s)),
+              }
+            : e,
+        ),
+      };
+      setActive(next);
+    },
+    [active],
+  );
+
+  /** Delete a set and renumber the remaining sets. */
+  const removeSet = useCallback(
+    (exerciseId: string, n: number) => {
+      if (!active) return;
+      const next: WorkoutSession = {
+        ...active,
+        exercises: active.exercises.map((e) =>
+          e.exerciseId === exerciseId
+            ? {
+                ...e,
+                sets: e.sets
+                  .filter((s) => s.n !== n)
+                  .map((s, i) => ({ ...s, n: i + 1 })),
+              }
+            : e,
+        ),
+      };
+      setActive(next);
+    },
+    [active],
+  );
+
+  /** Set / replace the exercise-level note. */
+  const setExerciseNote = useCallback(
+    (exerciseId: string, name: string, note: string, variantId?: string) => {
+      const session = active ?? startSession(currentWorkoutKey);
+      const next: WorkoutSession = {
+        ...session,
+        exercises: session.exercises.map((e) => ({ ...e })),
+      };
+      const entry = getOrCreateLoggedExercise(next, exerciseId, name, variantId);
+      entry.note = note || undefined;
+      setActive(next);
+    },
+    [active, currentWorkoutKey],
+  );
+
+  /** End the current session and archive to history. */
+  const endWorkout = useCallback(() => {
+    if (!active) return;
+    const { sessions } = endSession(active);
+    setHistory(sessions);
+    setActive(null);
+  }, [active]);
+
+  /** Lookup helpers. */
+  const loggedFor = useCallback(
+    (exerciseId: string): LoggedExercise | undefined =>
+      active?.exercises.find((e) => e.exerciseId === exerciseId),
+    [active],
+  );
+
+  const lastSet = useCallback(
+    (exerciseId: string): LoggedSet | null => {
+      // Prefer today's most recent if any, otherwise look back through history.
+      const todays = loggedFor(exerciseId)?.sets;
+      if (todays && todays.length > 0) return todays[todays.length - 1];
+      return lastSetFor(exerciseId, history);
+    },
+    [loggedFor, history],
+  );
+
+  return {
+    active,
+    history,
+    hydrated,
+    ensureActive,
+    logSet,
+    editSet,
+    removeSet,
+    setExerciseNote,
+    endWorkout,
+    loggedFor,
+    lastSet,
+  };
+}
+
+export type WorkoutLogHook = ReturnType<typeof useWorkoutLog>;

--- a/lib/workout-log.ts
+++ b/lib/workout-log.ts
@@ -1,0 +1,178 @@
+// Set/rep tracking data model + localStorage helpers.
+// Persists workout sessions across page reloads. No backend yet.
+
+import { loadState, saveState } from "./storage";
+
+export interface LoggedSet {
+  /** Set ordinal within the exercise (1-indexed). */
+  n: number;
+  /** Weight in lbs. Empty / 0 = bodyweight or unloaded. */
+  weight: number;
+  /** Reps performed. Use 0 + duration for time-based sets. */
+  reps: number;
+  /** Optional duration in seconds for isometric / timed sets. */
+  durationSec?: number;
+  /** Free-text per-set note (RPE, "neutral grip", pain notes, etc). */
+  note?: string;
+  /** Epoch ms when the set was completed. */
+  completedAt: number;
+}
+
+export interface LoggedExercise {
+  /** Stable exercise id from EX (e.g. "barbell_floor_press") or "custom:<slug>" for ad-hoc entries. */
+  exerciseId: string;
+  /** Display name at the time it was logged (preserves history if exercise is later renamed). */
+  name: string;
+  /** Variant id if a machine variant was active. */
+  variantId?: string;
+  sets: LoggedSet[];
+  /** Free-text exercise-level note. */
+  note?: string;
+}
+
+export interface WorkoutSession {
+  /** Random id (timestamp + suffix). */
+  id: string;
+  /** Workout name from WORKOUTS, or free-text "Freestyle". */
+  workoutKey: string;
+  /** Epoch ms. */
+  startedAt: number;
+  /** Epoch ms or undefined while in-progress. */
+  endedAt?: number;
+  exercises: LoggedExercise[];
+}
+
+const SESSIONS_KEY = "workout-log:sessions";
+const ACTIVE_KEY = "workout-log:active";
+const PHOTOS_KEY = "equipment-photos";
+
+export type EquipmentPhoto = {
+  /** Exercise id this photo was captured against. */
+  exerciseId: string;
+  /** Data URL (base64). */
+  dataUrl: string;
+  /** Epoch ms. */
+  capturedAt: number;
+  /** Optional bucket label assigned later. */
+  bucket?: string;
+};
+
+export function loadSessions(): WorkoutSession[] {
+  return loadState<WorkoutSession[]>(SESSIONS_KEY, []);
+}
+
+export function saveSessions(sessions: WorkoutSession[]): void {
+  saveState(SESSIONS_KEY, sessions);
+}
+
+export function loadActiveSession(): WorkoutSession | null {
+  return loadState<WorkoutSession | null>(ACTIVE_KEY, null);
+}
+
+export function saveActiveSession(session: WorkoutSession | null): void {
+  saveState(ACTIVE_KEY, session);
+}
+
+/** Find or create the LoggedExercise entry inside the active session. */
+export function getOrCreateLoggedExercise(
+  session: WorkoutSession,
+  exerciseId: string,
+  name: string,
+  variantId?: string,
+): LoggedExercise {
+  let entry = session.exercises.find((e) => e.exerciseId === exerciseId);
+  if (!entry) {
+    entry = { exerciseId, name, variantId, sets: [] };
+    session.exercises.push(entry);
+  } else if (variantId && entry.variantId !== variantId) {
+    entry.variantId = variantId;
+  }
+  return entry;
+}
+
+/** Most recent completed set for an exercise across all history. Used to prefill. */
+export function lastSetFor(
+  exerciseId: string,
+  sessions: WorkoutSession[],
+): LoggedSet | null {
+  for (let i = sessions.length - 1; i >= 0; i--) {
+    const ex = sessions[i].exercises.find((e) => e.exerciseId === exerciseId);
+    if (ex && ex.sets.length > 0) return ex.sets[ex.sets.length - 1];
+  }
+  return null;
+}
+
+export function newSessionId(): string {
+  return `s-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+export function startSession(workoutKey: string): WorkoutSession {
+  return {
+    id: newSessionId(),
+    workoutKey,
+    startedAt: Date.now(),
+    exercises: [],
+  };
+}
+
+/** Complete and archive a session: move active → sessions[]. */
+export function endSession(active: WorkoutSession): {
+  ended: WorkoutSession;
+  sessions: WorkoutSession[];
+} {
+  const ended: WorkoutSession = { ...active, endedAt: Date.now() };
+  const sessions = [...loadSessions(), ended];
+  saveSessions(sessions);
+  saveActiveSession(null);
+  return { ended, sessions };
+}
+
+// ── Equipment photos ──
+
+export function loadEquipmentPhotos(): EquipmentPhoto[] {
+  return loadState<EquipmentPhoto[]>(PHOTOS_KEY, []);
+}
+
+export function saveEquipmentPhotos(photos: EquipmentPhoto[]): void {
+  saveState(PHOTOS_KEY, photos);
+}
+
+export function addEquipmentPhoto(
+  exerciseId: string,
+  dataUrl: string,
+): EquipmentPhoto[] {
+  const photos = loadEquipmentPhotos();
+  const next = [
+    ...photos,
+    { exerciseId, dataUrl, capturedAt: Date.now() },
+  ];
+  saveEquipmentPhotos(next);
+  return next;
+}
+
+// ── Haptic feedback helper ──
+
+/** Trigger device vibration if supported. Single short pulse for "set done". */
+export function haptic(pattern: number | number[] = 30): void {
+  if (typeof navigator === "undefined") return;
+  // navigator.vibrate is widely supported on Android Chrome / Firefox; iOS Safari ignores.
+  if (typeof navigator.vibrate === "function") {
+    try {
+      navigator.vibrate(pattern);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+// ── Active-session expiry guard ──
+
+/** If the active session has been idle > 4hrs, treat it as abandoned. */
+export function isSessionStale(s: WorkoutSession): boolean {
+  const lastActivity =
+    s.exercises
+      .flatMap((e) => e.sets)
+      .reduce((acc, set) => Math.max(acc, set.completedAt), s.startedAt) ||
+    s.startedAt;
+  return Date.now() - lastActivity > 4 * 60 * 60 * 1000;
+}


### PR DESCRIPTION
Foundation for the in-app set tracker (feat/in-app-set-tracker).
Standalone lib file — not wired into UI yet. Defines:

- LoggedSet / LoggedExercise / WorkoutSession types
- loadSessions / saveSessions / loadActiveSession / saveActiveSession
- startSession / endSession / lastSetFor (auto-fill source)
- Equipment photo storage (separate localStorage key)
- haptic() wrapper around navigator.vibrate
- isSessionStale (4hr idle guard)

UI components and ExerciseRow integration are next.