### PR TITLE
fix(sw): network-first HTML to prevent stale-shell after deploys

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'nwb-plan-v6';
+const CACHE = 'nwb-plan-v7';
 const PRECACHE_URLS = [
   '/',
   '/manifest.json',
@@ -14,9 +14,9 @@ self.addEventListener('install', e => {
 
 self.addEventListener('activate', e => {
   e.waitUntil(
-    caches.keys().then(keys =>
-      Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))
-    )
+    caches.keys()
+      .then(keys => Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k))))
+      .then(() => self.clients.claim())
   );
 });
 
@@ -26,6 +26,25 @@ self.addEventListener('fetch', e => {
   const url = new URL(e.request.url);
   if (url.pathname.startsWith('/api/') || url.pathname.startsWith('/_next/')) return;
 
+  // Network-first for navigations: a stale HTML shell would reference dead
+  // hashed asset URLs after a deploy, breaking the page entirely. Always
+  // ask the network for HTML when we can; fall back to cache only offline.
+  if (e.request.mode === 'navigate') {
+    e.respondWith(
+      fetch(e.request)
+        .then(resp => {
+          if (resp && resp.status === 200 && resp.type === 'basic') {
+            const clone = resp.clone();
+            caches.open(CACHE).then(c => c.put(e.request, clone));
+          }
+          return resp;
+        })
+        .catch(() => caches.match(e.request).then(c => c || caches.match('/')))
+    );
+    return;
+  }
+
+  // Cache-first for static precached assets (manifest, icons).
   e.respondWith(
     caches.match(e.request).then(cached => {
       if (cached) return cached;
@@ -34,10 +53,6 @@ self.addEventListener('fetch', e => {
         const clone = resp.clone();
         caches.open(CACHE).then(c => c.put(e.request, clone));
         return resp;
-      }).catch(() => {
-        if (e.request.mode === 'navigate') {
-          return caches.match('/');
-        }
       });
     })
   );


### PR DESCRIPTION
## Summary
- The service worker precached \`/\` and served HTML cache-first. After every Vercel deploy, that stale shell referenced chunk filenames whose content hashes had changed — the new chunks 404'd, Safari parsed the empty CSS as zero rules, and the page rendered with default UA fonts and no layout. Diagnosed live today: cached HTML pointed at \`033yfl.27bisd.css\` (404); the live HTML was on \`0w-3gg2mklvjs.css\` (200).
- Switch HTML/navigation requests to **network-first**, falling back to cache only offline. Asset chunk requests (\`/_next/*\`) were already pass-through; static precached assets (manifest, icons) stay cache-first.
- Bump \`CACHE\` v6 → v7 so existing users on the bad shell evict on next visit. Add \`clients.claim()\` so the new SW takes over without waiting for all tabs to close.

## Test plan
- [ ] Hit the preview URL in Safari **with the v6 SW already registered** (mirrors the broken state). Expect: first load may still be broken (v6 still in control), then SW updates, **second load is clean**.
- [ ] Hit the preview URL in Safari **fresh / private window**. Expect: clean styled render on first load.
- [ ] In Web Inspector → Application → Service Workers, confirm v7 active and v6 caches purged.
- [ ] DevTools → throttle to Offline → reload. Expect: served from cache, not blank page.
- [ ] iOS Safari (PWA install) flow still works.
- [ ] Existing 9 set-tracker e2e tests pass (unrelated, but confirms no regression in test suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)