### PR TITLE
fix(sw): network-first HTML to prevent stale-shell after deploys (prod)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'nwb-plan-v6';
+const CACHE = 'nwb-plan-v7';
 const PRECACHE_URLS = [
   '/',
   '/manifest.json',
@@ -14,9 +14,9 @@ self.addEventListener('install', e => {
 
 self.addEventListener('activate', e => {
   e.waitUntil(
-    caches.keys().then(keys =>
-      Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))
-    )
+    caches.keys()
+      .then(keys => Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k))))
+      .then(() => self.clients.claim())
   );
 });
 
@@ -26,6 +26,25 @@ self.addEventListener('fetch', e => {
   const url = new URL(e.request.url);
   if (url.pathname.startsWith('/api/') || url.pathname.startsWith('/_next/')) return;
 
+  // Network-first for navigations: a stale HTML shell would reference dead
+  // hashed asset URLs after a deploy, breaking the page entirely. Always
+  // ask the network for HTML when we can; fall back to cache only offline.
+  if (e.request.mode === 'navigate') {
+    e.respondWith(
+      fetch(e.request)
+        .then(resp => {
+          if (resp && resp.status === 200 && resp.type === 'basic') {
+            const clone = resp.clone();
+            caches.open(CACHE).then(c => c.put(e.request, clone));
+          }
+          return resp;
+        })
+        .catch(() => caches.match(e.request).then(c => c || caches.match('/')))
+    );
+    return;
+  }
+
+  // Cache-first for static precached assets (manifest, icons).
   e.respondWith(
     caches.match(e.request).then(cached => {
       if (cached) return cached;
@@ -34,10 +53,6 @@ self.addEventListener('fetch', e => {
         const clone = resp.clone();
         caches.open(CACHE).then(c => c.put(e.request, clone));
         return resp;
-      }).catch(() => {
-        if (e.request.mode === 'navigate') {
-          return caches.match('/');
-        }
       });
     })
   );


### PR DESCRIPTION
Cherry-pick of #85 onto \`main\` so prod (\`nfit.93.fyi\`) gets the same fix without waiting for the next dev → main promotion.

## Why now
Service worker on \`dev.nfit.93.fyi\` was serving a cache-first HTML shell that referenced hashed asset URLs from a previous build. After Vercel redeployed, those chunks 404'd and Safari rendered with default UA fonts and zero CSS. \`nfit.93.fyi\` runs the same SW and is vulnerable to the identical failure mode on every prod deploy.

## What changes
- HTML/navigation requests: cache-first → **network-first** with cache fallback only when offline.
- Asset chunks (\`/_next/*\`) and \`/api/*\`: pass-through, unchanged.
- Static precached assets (manifest, icons): cache-first, unchanged.
- \`CACHE\` v6 → v7 to evict any users currently on a bad shell.
- \`clients.claim()\` so the new SW takes over without waiting for all tabs to close.

## Test plan
- [ ] Confirm preview deploy renders cleanly in Safari.
- [ ] Verify offline fallback still serves \`/\` from cache (DevTools → Offline → reload).
- [ ] Existing 9 set-tracker e2e tests pass (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)