### PR TITLE
feat(set-tracker): surface in play mode + auto-expand on add

### DIFF
--- a/components/workout-view.tsx
+++ b/components/workout-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useLayoutEffect, useCallback, useRef, useMemo } from "react";
+import dynamic from "next/dynamic";
 import { loadState, saveState } from "@/lib/storage";
 import {
   EX,
@@ -43,6 +44,13 @@ import ComplementPicker, {
 } from "@/components/complement-picker";
 import { useLongPress } from "@/lib/use-long-press";
 import { cssAlpha } from "@/lib/css-utils";
+
+// Set tracker: same client-only pattern used in ExerciseRow. Disabling SSR
+// avoids a Turbopack chunk-init order issue when the tracker is bundled into
+// the SSR'd workout-view tree.
+const SetTracker = dynamic(() => import("@/components/set-tracker"), {
+  ssr: false,
+});
 
 // Conditionally import AuthButton only when feature flag is on
 const AuthButton =
@@ -1487,7 +1495,7 @@ export default function WorkoutView() {
             ex.machineVariants?.find((v) => v.id === selMachineId) ?? null;
 
           return (
-            <div key={origName}>
+            <div key={origName} data-exercise-name={exName}>
               {/* Swap indicator */}
               {exName !== origName && (
                 <div className="text-[10px] text-text-muted px-3 flex items-center gap-1">
@@ -3172,6 +3180,26 @@ export default function WorkoutView() {
                 <div className="text-white/75 text-[14px] leading-relaxed">{item.ex.nwbCues}</div>
               </div>
 
+              {/* In-app set tracker — primary action surface in play mode.
+                  `key` re-keys on exercise change so the draft state, prefill,
+                  and inputs reset cleanly when navigating between focus items. */}
+              <div className="mb-4">
+                <SetTracker
+                  key={item.ex.id}
+                  exerciseId={item.ex.id}
+                  exerciseName={item.name}
+                  variantId={
+                    item.ex.machineVariants?.find(
+                      (v) => v.id === machineSelections[item.name],
+                    )?.id
+                  }
+                  defaultRest={item.ex.rest}
+                  prescribedReps={s[1]}
+                  log={log}
+                  onStartTimer={(sec) => setTimer(sec)}
+                />
+              </div>
+
               <div
                 className="mb-4 rounded-2xl p-4"
                 style={{ background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.08)" }}
@@ -3386,7 +3414,14 @@ export default function WorkoutView() {
         />
       )}
 
-      {/* Add-exercise picker — "＋ Add exercise" button opens this */}
+      {/* Add-exercise picker — "＋ Add exercise" button opens this.
+          The picker itself is intentionally lean (search + tap-to-add). To
+          let the user log a set immediately on the new exercise without a
+          separate tap to expand it, we (a) make sure the workout section is
+          open, (b) auto-expand the freshly added row, and (c) scroll it
+          into view. The picker auto-closes on add (existing behavior), so
+          when the user lands back on the today view the new ExerciseRow is
+          already expanded with SetTracker visible at the top of its panel. */}
       {addPickerFor && (() => {
         const wk = addPickerFor;
         const w = WORKOUTS[wk];
@@ -3402,7 +3437,39 @@ export default function WorkoutView() {
           <AddExercisePicker
             currentExercises={current}
             preferredCategory={preferred}
-            onAdd={(name) => addExerciseToWorkout(wk, name)}
+            onAdd={(name) => {
+              addExerciseToWorkout(wk, name);
+              // Ensure the workout section is open so the row is visible.
+              setOpenSections((prev) =>
+                prev[wk] ? prev : { ...prev, [wk]: true },
+              );
+              // Auto-expand the new exercise row so its SetTracker is
+              // immediately tappable. Note: getExName(wk, name) === name
+              // for freshly added exercises (no swap mapping yet).
+              setExpandedEx((prev) =>
+                prev[name] ? prev : { ...prev, [name]: true },
+              );
+              // Scroll the new row into view after the picker closes.
+              // Each row in renderWorkout is tagged with data-exercise-name
+              // so we can find it deterministically without a ref. The
+              // double rAF gives React a tick to paint the new addition +
+              // expanded panel before we scroll.
+              if (typeof window !== "undefined") {
+                requestAnimationFrame(() => {
+                  requestAnimationFrame(() => {
+                    const el = document.querySelector(
+                      `[data-exercise-name="${CSS.escape(name)}"]`,
+                    );
+                    if (el && "scrollIntoView" in el) {
+                      (el as HTMLElement).scrollIntoView({
+                        behavior: "smooth",
+                        block: "center",
+                      });
+                    }
+                  });
+                });
+              }
+            }}
             onClose={() => setAddPickerFor(null)}
           />
         );


### PR DESCRIPTION
## Summary
Logs sets without leaving the active context. Two new surfaces:

- **Play mode (focus overlay):** `<SetTracker>` rendered between the NWB Safety card and Breathing card for the current focus item, keyed on `item.ex.id` so draft state re-initializes when navigating Next/Prev/dot. Wired with `log` (parent-scoped `useWorkoutLog(todayWorkoutKey)` from line 2726 — TDZ trap respected), `defaultRest`, `prescribedReps`, and `onStartTimer`.
- **Add-exercise picker:** picker stays lean (presentational + auto-close). On add, `onAdd` callback now (1) calls `addExerciseToWorkout`, (2) opens the section, (3) expands the new row, (4) double-rAF scrolls into view. User taps in picker → picker closes → row appears expanded with SetTracker visible. Zero extra taps.

Single file touched: `components/workout-view.tsx` (+70 / -3).

## Test plan
- [ ] Focus mode: tap an exercise's ▶ → SetTracker appears with correct prescribed-reps prefill; Next/Prev re-keys cleanly.
- [ ] Add-exercise picker: pick an exercise → picker closes → new row is expanded with SetTracker visible at the top of its panel.
- [ ] Existing expanded-row SetTracker still works (additive change).
- [ ] Logged sets persist to `workout-log:active`/`workout-log:sessions` from any of the three surfaces.
- [ ] Existing 9 set-tracker e2e tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)