### PR TITLE
feat(hevy): client-side Hevy CSV import flow

### DIFF
--- a/components/hevy-import-panel.tsx
+++ b/components/hevy-import-panel.tsx
@@ -1,0 +1,434 @@
+"use client";
+
+/**
+ * HevyImportPanel — Client-side Hevy CSV import UI.
+ *
+ * Renders inside the Equipment tab. On file selection:
+ *   1. Reads and parses the CSV entirely in the browser.
+ *   2. Shows a confirmation panel with match/skip counts.
+ *   3. "Import" appends parsed sessions to workout-log:sessions.
+ *   4. "Cancel" discards the parse result.
+ */
+
+import React, { useRef, useState, useCallback } from "react";
+import { parseHevyCsv, type HevyImportResult } from "@/lib/hevy-import";
+import { loadSessions, saveSessions } from "@/lib/workout-log";
+
+type ImportState =
+  | { phase: "idle" }
+  | { phase: "parsed"; result: HevyImportResult; filename: string }
+  | { phase: "success"; count: number }
+  | { phase: "error"; message: string };
+
+export default function HevyImportPanel() {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [state, setState] = useState<ImportState>({ phase: "idle" });
+
+  const handleFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = (ev) => {
+        try {
+          const text = ev.target?.result as string;
+          const result = parseHevyCsv(text);
+          setState({ phase: "parsed", result, filename: file.name });
+        } catch (err) {
+          setState({
+            phase: "error",
+            message:
+              err instanceof Error ? err.message : "Failed to parse CSV",
+          });
+        }
+      };
+      reader.onerror = () =>
+        setState({ phase: "error", message: "Could not read file" });
+      reader.readAsText(file);
+      // Reset input so same file can be re-selected after cancel
+      e.target.value = "";
+    },
+    [],
+  );
+
+  const handleImport = useCallback(() => {
+    if (state.phase !== "parsed") return;
+    const existing = loadSessions();
+    saveSessions([...existing, ...state.result.matched]);
+    setState({ phase: "success", count: state.result.matched.length });
+  }, [state]);
+
+  const handleCancel = useCallback(() => {
+    setState({ phase: "idle" });
+  }, []);
+
+  const handleReset = useCallback(() => {
+    setState({ phase: "idle" });
+  }, []);
+
+  return (
+    <div
+      style={{
+        borderRadius: 12,
+        border: "1px solid var(--color-border)",
+        background: "var(--color-card)",
+        overflow: "hidden",
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          padding: "12px 14px 10px",
+          borderBottom: "1px solid var(--color-border)",
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+        }}
+      >
+        <span style={{ fontSize: 16 }}>📥</span>
+        <div>
+          <div style={{ fontSize: 13, fontWeight: 700, color: "var(--color-text)" }}>
+            Import from Hevy
+          </div>
+          <div style={{ fontSize: 11, color: "var(--color-text-muted)", marginTop: 1 }}>
+            Upload a Hevy CSV export to prefill SetTracker weights
+          </div>
+        </div>
+      </div>
+
+      <div style={{ padding: "12px 14px" }}>
+        {/* ── IDLE ── */}
+        {state.phase === "idle" && (
+          <div>
+            <div
+              style={{
+                fontSize: 11,
+                color: "var(--color-text-muted)",
+                marginBottom: 10,
+                lineHeight: 1.5,
+              }}
+            >
+              In Hevy: Profile → Settings → Export Workouts → CSV. Then upload
+              below. Parsing is 100% offline — no data leaves your device.
+            </div>
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              style={{
+                display: "block",
+                width: "100%",
+                padding: "10px 0",
+                borderRadius: 8,
+                border: "1.5px dashed var(--color-border)",
+                background: "transparent",
+                color: "var(--color-accent)",
+                fontSize: 13,
+                fontWeight: 600,
+                cursor: "pointer",
+                fontFamily: "inherit",
+                letterSpacing: 0.2,
+              }}
+            >
+              Choose .csv file
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".csv,text/csv"
+              onChange={handleFileChange}
+              style={{ display: "none" }}
+            />
+          </div>
+        )}
+
+        {/* ── PARSED — confirmation panel ── */}
+        {state.phase === "parsed" && (
+          <ParsedPanel
+            result={state.result}
+            filename={state.filename}
+            onImport={handleImport}
+            onCancel={handleCancel}
+          />
+        )}
+
+        {/* ── SUCCESS ── */}
+        {state.phase === "success" && (
+          <div>
+            <div
+              style={{
+                padding: "10px 12px",
+                borderRadius: 8,
+                background: "var(--color-safe-bg)",
+                border: "1px solid var(--color-safe-border)",
+                color: "var(--color-safe)",
+                fontSize: 13,
+                fontWeight: 600,
+                marginBottom: 10,
+              }}
+            >
+              Imported {state.count} workout session
+              {state.count !== 1 ? "s" : ""}. Weights will prefill in
+              SetTracker.
+            </div>
+            <button
+              onClick={handleReset}
+              style={{
+                fontSize: 12,
+                color: "var(--color-text-muted)",
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                padding: 0,
+                fontFamily: "inherit",
+                textDecoration: "underline",
+              }}
+            >
+              Import another file
+            </button>
+          </div>
+        )}
+
+        {/* ── ERROR ── */}
+        {state.phase === "error" && (
+          <div>
+            <div
+              style={{
+                padding: "10px 12px",
+                borderRadius: 8,
+                background: "var(--color-danger-bg, #fee2e2)",
+                border: "1px solid var(--color-danger-border, #fca5a5)",
+                color: "var(--color-danger, #dc2626)",
+                fontSize: 12,
+                marginBottom: 10,
+              }}
+            >
+              {state.message}
+            </div>
+            <button
+              onClick={handleReset}
+              style={{
+                fontSize: 12,
+                color: "var(--color-text-muted)",
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                padding: 0,
+                fontFamily: "inherit",
+                textDecoration: "underline",
+              }}
+            >
+              Try again
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Confirmation sub-panel ────────────────────────────────────────────────────
+
+interface ParsedPanelProps {
+  result: HevyImportResult;
+  filename: string;
+  onImport: () => void;
+  onCancel: () => void;
+}
+
+function ParsedPanel({ result, filename, onImport, onCancel }: ParsedPanelProps) {
+  const [showSkipped, setShowSkipped] = useState(false);
+
+  const matchedExCount = result.matched.reduce(
+    (acc, s) => acc + s.exercises.length,
+    0,
+  );
+
+  return (
+    <div>
+      {/* Summary line */}
+      <div
+        style={{
+          fontSize: 12,
+          color: "var(--color-text-muted)",
+          marginBottom: 8,
+          wordBreak: "break-all",
+        }}
+      >
+        {filename}
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr 1fr",
+          gap: 6,
+          marginBottom: 12,
+        }}
+      >
+        <StatChip
+          label="Workouts"
+          value={result.matched.length}
+          color="var(--color-safe)"
+        />
+        <StatChip
+          label="Exercises matched"
+          value={matchedExCount}
+          color="var(--color-accent)"
+        />
+        <StatChip
+          label="Exercises skipped"
+          value={result.skipped.length}
+          color={
+            result.skipped.length > 0
+              ? "var(--color-caution, #f59e0b)"
+              : "var(--color-text-muted)"
+          }
+        />
+      </div>
+
+      {/* Skipped list (collapsible) */}
+      {result.skipped.length > 0 && (
+        <div style={{ marginBottom: 12 }}>
+          <button
+            onClick={() => setShowSkipped((v) => !v)}
+            style={{
+              fontSize: 11,
+              color: "var(--color-text-muted)",
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              padding: "0 0 4px",
+              fontFamily: "inherit",
+              textDecoration: "underline",
+            }}
+          >
+            {showSkipped ? "Hide" : "Show"} skipped exercises (
+            {result.skipped.length})
+          </button>
+          {showSkipped && (
+            <div
+              style={{
+                borderRadius: 6,
+                border: "1px solid var(--color-border)",
+                background: "var(--color-bg)",
+                padding: "6px 10px",
+                maxHeight: 160,
+                overflowY: "auto",
+              }}
+            >
+              {result.skipped.map((s) => (
+                <div
+                  key={s.name}
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    fontSize: 11,
+                    color: "var(--color-text-muted)",
+                    padding: "3px 0",
+                    borderBottom: "1px solid var(--color-border)",
+                  }}
+                >
+                  <span style={{ marginRight: 8 }}>{s.name}</span>
+                  <span style={{ flexShrink: 0 }}>
+                    {s.sets} set{s.sets !== 1 ? "s" : ""}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {result.matched.length === 0 && (
+        <div
+          style={{
+            fontSize: 12,
+            color: "var(--color-caution, #f59e0b)",
+            marginBottom: 10,
+          }}
+        >
+          No exercises could be matched to the NWB library. Nothing will be
+          imported.
+        </div>
+      )}
+
+      {/* Buttons */}
+      <div style={{ display: "flex", gap: 8 }}>
+        <button
+          onClick={onImport}
+          disabled={result.matched.length === 0}
+          style={{
+            flex: 1,
+            padding: "9px 0",
+            borderRadius: 8,
+            border: "none",
+            background:
+              result.matched.length === 0
+                ? "var(--color-border)"
+                : "var(--color-accent)",
+            color:
+              result.matched.length === 0
+                ? "var(--color-text-muted)"
+                : "#fff",
+            fontSize: 13,
+            fontWeight: 700,
+            cursor:
+              result.matched.length === 0 ? "not-allowed" : "pointer",
+            fontFamily: "inherit",
+          }}
+        >
+          Import {result.matched.length > 0 ? result.matched.length : ""}{" "}
+          Session{result.matched.length !== 1 ? "s" : ""}
+        </button>
+        <button
+          onClick={onCancel}
+          style={{
+            padding: "9px 16px",
+            borderRadius: 8,
+            border: "1px solid var(--color-border)",
+            background: "transparent",
+            color: "var(--color-text-muted)",
+            fontSize: 13,
+            cursor: "pointer",
+            fontFamily: "inherit",
+          }}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface StatChipProps {
+  label: string;
+  value: number;
+  color: string;
+}
+
+function StatChip({ label, value, color }: StatChipProps) {
+  return (
+    <div
+      style={{
+        borderRadius: 8,
+        border: "1px solid var(--color-border)",
+        background: "var(--color-bg)",
+        padding: "8px 6px",
+        textAlign: "center",
+      }}
+    >
+      <div style={{ fontSize: 18, fontWeight: 700, color }}>
+        {value}
+      </div>
+      <div
+        style={{
+          fontSize: 10,
+          color: "var(--color-text-muted)",
+          marginTop: 2,
+          lineHeight: 1.3,
+        }}
+      >
+        {label}
+      </div>
+    </div>
+  );
+}

--- a/components/workout-view.tsx
+++ b/components/workout-view.tsx
@@ -43,6 +43,7 @@ import ComplementPicker, {
 } from "@/components/complement-picker";
 import { useLongPress } from "@/lib/use-long-press";
 import { cssAlpha } from "@/lib/css-utils";
+import HevyImportPanel from "@/components/hevy-import-panel";
 
 // Conditionally import AuthButton only when feature flag is on
 const AuthButton =
@@ -2455,6 +2456,11 @@ export default function WorkoutView() {
             </div>
           ))}
         </Section>
+
+        {/* Hevy CSV import */}
+        <div style={{ marginTop: 8 }}>
+          <HevyImportPanel />
+        </div>
       </div>
     );
   }

--- a/lib/hevy-import.ts
+++ b/lib/hevy-import.ts
@@ -1,0 +1,326 @@
+/**
+ * Client-side Hevy CSV import.
+ *
+ * Hevy CSV format (one row per set):
+ *   Workout #, Date, Workout Name, Duration, Exercise Name,
+ *   Set Order, Weight (kg), Reps, RPE, Distance (km), Duration (s),
+ *   Notes, Workout Notes
+ *
+ * Columns vary by Hevy version; we locate columns by header name.
+ * Everything is parsed in-browser — no backend required.
+ */
+
+import { findExerciseId } from "./hevy-name-map";
+import type { WorkoutSession, LoggedSet, LoggedExercise } from "./workout-log";
+import { newSessionId } from "./workout-log";
+
+// ── CSV parser (no external deps) ────────────────────────────────────────────
+
+/**
+ * Parse a CSV string into rows of string cells.
+ *
+ * Handles:
+ *   - Quoted fields (may contain commas)
+ *   - Escaped double-quotes inside quoted fields ("")
+ *   - \r\n and \n line endings
+ *   - Trailing newlines
+ */
+export function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  // Normalize line endings
+  const normalized = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  let i = 0;
+  const len = normalized.length;
+
+  while (i < len) {
+    const row: string[] = [];
+    // Parse one row
+    while (i < len && normalized[i] !== "\n") {
+      if (normalized[i] === '"') {
+        // Quoted field
+        i++; // skip opening quote
+        let cell = "";
+        while (i < len) {
+          if (normalized[i] === '"') {
+            if (normalized[i + 1] === '"') {
+              // Escaped double-quote
+              cell += '"';
+              i += 2;
+            } else {
+              // End of quoted field
+              i++;
+              break;
+            }
+          } else {
+            cell += normalized[i];
+            i++;
+          }
+        }
+        row.push(cell);
+        // Skip comma after quoted field (if any)
+        if (i < len && normalized[i] === ",") i++;
+      } else {
+        // Unquoted field — read until comma or newline
+        let start = i;
+        while (i < len && normalized[i] !== "," && normalized[i] !== "\n") {
+          i++;
+        }
+        row.push(normalized.slice(start, i));
+        if (i < len && normalized[i] === ",") i++;
+      }
+    }
+    // Skip the newline character
+    if (i < len && normalized[i] === "\n") i++;
+    // Skip completely empty rows (e.g. trailing newline produces one)
+    if (row.length > 1 || (row.length === 1 && row[0] !== "")) {
+      rows.push(row);
+    }
+  }
+  return rows;
+}
+
+// ── kg → lb conversion ───────────────────────────────────────────────────────
+
+const KG_TO_LB = 2.20462;
+
+/** Convert kg to lb, rounded to nearest 2.5. Returns 0 if input is falsy/NaN. */
+function kgToLb(kg: number): number {
+  if (!kg || isNaN(kg)) return 0;
+  const raw = kg * KG_TO_LB;
+  return Math.round(raw / 2.5) * 2.5;
+}
+
+// ── Result types ─────────────────────────────────────────────────────────────
+
+export interface SkippedExercise {
+  name: string;
+  sets: number;
+}
+
+export interface HevyImportResult {
+  /** Sessions fully matched and ready to append to workout-log:sessions. */
+  matched: WorkoutSession[];
+  /** Exercises that had no mapping. Aggregated by name. */
+  skipped: SkippedExercise[];
+  /** Total raw CSV data rows (excluding header). */
+  rawCount: number;
+}
+
+// ── Column header aliases ─────────────────────────────────────────────────────
+
+/**
+ * Hevy has changed column headers across export versions. We try a list of
+ * known aliases for each logical column.
+ */
+const COL_ALIASES: Record<string, string[]> = {
+  workoutNum: ["workout #", "workout number", "workout#"],
+  date: ["date"],
+  workoutName: ["workout name", "title"],
+  exerciseName: ["exercise name", "exercise", "exercise title"],
+  setOrder: ["set order", "set #", "set number"],
+  weightKg: ["weight (kg)", "weight_kg", "weight kg"],
+  weightLb: ["weight (lbs)", "weight (lb)", "weight_lbs", "weight lb"],
+  reps: ["reps", "repetitions"],
+  notes: ["notes", "note"],
+  workoutNotes: ["workout notes", "workout note"],
+  durationSec: ["duration (s)", "duration(s)", "time (s)", "time"],
+};
+
+function findColIndex(
+  headers: string[],
+  aliases: string[],
+): number {
+  const lower = headers.map((h) => h.toLowerCase().trim());
+  for (const alias of aliases) {
+    const idx = lower.indexOf(alias);
+    if (idx !== -1) return idx;
+  }
+  return -1;
+}
+
+// ── Main parser ───────────────────────────────────────────────────────────────
+
+/**
+ * Parse a Hevy CSV export and return matched sessions, skipped exercises, and
+ * the raw row count.
+ *
+ * Logic:
+ *  1. Parse CSV → rows.
+ *  2. Locate columns by header aliases.
+ *  3. Group rows by (workoutNum + date) → session.
+ *  4. Within each session group, group rows by exerciseName → LoggedExercise.
+ *  5. Convert weights (kg → lb) and build LoggedSet entries.
+ *  6. If exerciseName maps to an id: include in session.exercises.
+ *     Otherwise: aggregate to skipped[].
+ *  7. Only emit a session if it has at least one matched exercise.
+ */
+export function parseHevyCsv(csvText: string): HevyImportResult {
+  const rows = parseCsv(csvText);
+  if (rows.length < 2) {
+    return { matched: [], skipped: [], rawCount: 0 };
+  }
+
+  const headers = rows[0];
+  const dataRows = rows.slice(1);
+
+  // Locate columns
+  const colWorkoutNum = findColIndex(headers, COL_ALIASES.workoutNum);
+  const colDate = findColIndex(headers, COL_ALIASES.date);
+  const colWorkoutName = findColIndex(headers, COL_ALIASES.workoutName);
+  const colExerciseName = findColIndex(headers, COL_ALIASES.exerciseName);
+  const colSetOrder = findColIndex(headers, COL_ALIASES.setOrder);
+  const colWeightKg = findColIndex(headers, COL_ALIASES.weightKg);
+  const colWeightLb = findColIndex(headers, COL_ALIASES.weightLb);
+  const colReps = findColIndex(headers, COL_ALIASES.reps);
+  const colNotes = findColIndex(headers, COL_ALIASES.notes);
+  const colDurationSec = findColIndex(headers, COL_ALIASES.durationSec);
+
+  if (colExerciseName === -1) {
+    // Can't parse without knowing which column is the exercise name
+    return { matched: [], skipped: [], rawCount: dataRows.length };
+  }
+
+  const get = (row: string[], col: number): string =>
+    col !== -1 ? (row[col] ?? "").trim() : "";
+
+  // ── Group rows by session key (workout# + date) ──
+  // Using a Map to preserve insertion order
+  const sessionMap = new Map<
+    string,
+    {
+      workoutNum: string;
+      date: string;
+      workoutName: string;
+      exercises: Map<string, { rows: string[][] }>;
+    }
+  >();
+
+  for (const row of dataRows) {
+    const wNum = get(row, colWorkoutNum) || "0";
+    const date = get(row, colDate) || "unknown";
+    const wName = get(row, colWorkoutName) || "Hevy Workout";
+    const exName = get(row, colExerciseName);
+    if (!exName) continue;
+
+    const sessionKey = `${wNum}::${date}`;
+    if (!sessionMap.has(sessionKey)) {
+      sessionMap.set(sessionKey, {
+        workoutNum: wNum,
+        date,
+        workoutName: wName,
+        exercises: new Map(),
+      });
+    }
+    const session = sessionMap.get(sessionKey)!;
+    if (!session.exercises.has(exName)) {
+      session.exercises.set(exName, { rows: [] });
+    }
+    session.exercises.get(exName)!.rows.push(row);
+  }
+
+  // ── Build sessions ──
+  const matched: WorkoutSession[] = [];
+  const skippedMap = new Map<string, number>(); // name → total skipped sets
+
+  for (const [, sessionData] of sessionMap) {
+    const { date, workoutName, exercises } = sessionData;
+
+    // Parse date → epoch ms. Hevy uses YYYY-MM-DD or MM/DD/YYYY etc.
+    const startedAt = parseHevyDate(date);
+
+    const loggedExercises: LoggedExercise[] = [];
+
+    for (const [exName, exData] of exercises) {
+      const exerciseId = findExerciseId(exName);
+
+      if (!exerciseId) {
+        // Track skipped
+        skippedMap.set(exName, (skippedMap.get(exName) ?? 0) + exData.rows.length);
+        continue;
+      }
+
+      // Determine if source is kg or lb
+      const useLbColumn = colWeightLb !== -1 && colWeightKg === -1;
+
+      const sets: LoggedSet[] = exData.rows.map((row, idx) => {
+        let weight = 0;
+        if (useLbColumn) {
+          weight = parseFloat(get(row, colWeightLb)) || 0;
+        } else if (colWeightKg !== -1) {
+          weight = kgToLb(parseFloat(get(row, colWeightKg)) || 0);
+        }
+
+        const reps = parseInt(get(row, colReps), 10) || 0;
+        const durationSec =
+          colDurationSec !== -1
+            ? parseInt(get(row, colDurationSec), 10) || undefined
+            : undefined;
+        const note = colNotes !== -1 ? get(row, colNotes) || undefined : undefined;
+
+        // Ordinal: prefer Set Order column; fall back to loop index + 1
+        const nRaw = colSetOrder !== -1 ? parseInt(get(row, colSetOrder), 10) : NaN;
+        const n = isNaN(nRaw) ? idx + 1 : nRaw;
+
+        return {
+          n,
+          weight,
+          reps,
+          ...(durationSec !== undefined ? { durationSec } : {}),
+          ...(note ? { note } : {}),
+          completedAt: startedAt,
+        } satisfies LoggedSet;
+      });
+
+      loggedExercises.push({
+        exerciseId,
+        name: exName,
+        sets,
+      });
+    }
+
+    if (loggedExercises.length === 0) continue;
+
+    matched.push({
+      id: newSessionId(),
+      workoutKey: workoutName,
+      startedAt,
+      endedAt: startedAt + 60 * 60 * 1000, // assume ~1 hr duration
+      exercises: loggedExercises,
+    });
+  }
+
+  const skipped: SkippedExercise[] = Array.from(skippedMap.entries()).map(
+    ([name, sets]) => ({ name, sets }),
+  );
+
+  return { matched, skipped, rawCount: dataRows.length };
+}
+
+// ── Date parsing ─────────────────────────────────────────────────────────────
+
+/**
+ * Parse Hevy date strings to epoch ms.
+ *
+ * Known Hevy formats:
+ *   "2024-03-15" (ISO)
+ *   "Mar 15, 2024"
+ *   "2024-03-15 09:30:00" (with time)
+ */
+function parseHevyDate(dateStr: string): number {
+  // Try native parse first — works for ISO 8601 and many locale strings
+  const native = new Date(dateStr);
+  if (!isNaN(native.getTime())) return native.getTime();
+
+  // Fallback: YYYY-MM-DD
+  const iso = dateStr.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (iso) {
+    return new Date(
+      parseInt(iso[1]),
+      parseInt(iso[2]) - 1,
+      parseInt(iso[3]),
+    ).getTime();
+  }
+
+  // Can't parse — use now as fallback
+  return Date.now();
+}

--- a/lib/hevy-name-map.ts
+++ b/lib/hevy-name-map.ts
@@ -1,0 +1,209 @@
+/**
+ * Hevy → NWB-Plan exercise name map.
+ *
+ * Keys: Hevy "Exercise Name" column, lowercased + whitespace-normalized.
+ * Values: exercise id from lib/exercises.ts EX[key].id
+ *
+ * Hevy uses verbose names like "Bench Press (Barbell)" while NWB-Plan ids
+ * are snake_case slugs. We map by gym-vocabulary equivalence; NWB exercises
+ * are unilateral/NWB-adapted, so we map the generic Hevy name → the NWB
+ * single-leg or adapted variant that makes sense.
+ *
+ * ~35 pairs covering the most common push/pull/legs/core exercises a Hevy
+ * user would have logged before switching to this app.
+ */
+export const HEVY_NAME_MAP: Record<string, string> = {
+  // ── PUSH / CHEST ─────────────────────────────────────────────────────────
+  "bench press (barbell)": "barbell_floor_press",
+  "bench press": "barbell_floor_press",
+  "floor press (barbell)": "barbell_floor_press",
+  "barbell floor press": "barbell_floor_press",
+
+  "incline bench press (dumbbell)": "incline_db_bench_press",
+  "incline dumbbell bench press": "incline_db_bench_press",
+  "incline db press": "incline_db_bench_press",
+
+  "chest press (machine)": "machine_chest_press",
+  "chest press machine": "machine_chest_press",
+  "machine chest press": "machine_chest_press",
+
+  "cable chest fly": "cable_chest_fly",
+  "cable fly": "cable_chest_fly",
+  "cable crossover": "cable_chest_fly",
+  "pec deck": "cable_chest_fly",
+  "pec deck fly": "cable_chest_fly",
+
+  // ── PUSH / SHOULDER ───────────────────────────────────────────────────────
+  "overhead press (dumbbell)": "seated_db_oh_press",
+  "shoulder press (dumbbell)": "seated_db_oh_press",
+  "seated dumbbell shoulder press": "seated_db_oh_press",
+  "dumbbell shoulder press": "seated_db_oh_press",
+
+  "arnold press (dumbbell)": "seated_arnold_press",
+  "arnold press": "seated_arnold_press",
+
+  "lateral raise (dumbbell)": "cable_lateral_raise_seated",
+  "lateral raise (cable)": "cable_lateral_raise_seated",
+  "cable lateral raise": "cable_lateral_raise_seated",
+  "side lateral raise": "cable_lateral_raise_seated",
+
+  "shoulder press (machine)": "machine_shoulder_press",
+  "machine shoulder press": "machine_shoulder_press",
+
+  // ── PUSH / TRICEPS ────────────────────────────────────────────────────────
+  "skull crusher": "lying_skull_crushers",
+  "skull crushers": "lying_skull_crushers",
+  "lying tricep extension": "lying_skull_crushers",
+  "lying triceps extension": "lying_skull_crushers",
+
+  "tricep pushdown (cable - rope)": "tricep_rope_pushdown",
+  "tricep pushdown (rope)": "tricep_rope_pushdown",
+  "rope pushdown": "tricep_rope_pushdown",
+  "cable tricep pushdown": "tricep_rope_pushdown",
+  "tricep pushdown": "tricep_rope_pushdown",
+
+  "overhead tricep extension (dumbbell)": "oh_triceps_extension",
+  "overhead tricep extension (cable)": "oh_triceps_extension",
+  "overhead tricep extension": "oh_triceps_extension",
+
+  "tricep kickback (dumbbell)": "db_tricep_kickback",
+  "dumbbell tricep kickback": "db_tricep_kickback",
+
+  // ── PULL / BACK ───────────────────────────────────────────────────────────
+  "lat pulldown (bar)": "lat_pulldown_wide",
+  "lat pulldown (wide bar)": "lat_pulldown_wide",
+  "lat pulldown": "lat_pulldown_wide",
+  "wide grip lat pulldown": "lat_pulldown_wide",
+
+  "lat pulldown (neutral grip)": "neutral_grip_pulldown",
+  "neutral grip lat pulldown": "neutral_grip_pulldown",
+  "close grip lat pulldown": "neutral_grip_pulldown",
+
+  "pull-up": "weighted_pullup",
+  "pullup": "weighted_pullup",
+  "pull up": "weighted_pullup",
+  "weighted pull-up": "weighted_pullup",
+  "chin-up": "weighted_pullup",
+  "chin up": "weighted_pullup",
+
+  "bent over row (barbell)": "chest_supported_db_row",
+  "bent over row (dumbbell)": "chest_supported_db_row",
+  "chest supported row (dumbbell)": "chest_supported_db_row",
+  "incline row": "chest_supported_db_row",
+
+  "seated cable row": "seated_cable_row",
+  "cable row": "seated_cable_row",
+  "low cable row": "seated_cable_row",
+  "seated row (cable)": "seated_cable_row",
+
+  "single arm cable row": "one_arm_cable_row",
+  "one arm cable row": "one_arm_cable_row",
+  "single arm row (cable)": "one_arm_cable_row",
+
+  "face pull": "seated_face_pulls",
+  "face pulls": "seated_face_pulls",
+  "cable face pull": "seated_face_pulls",
+
+  "reverse fly (machine)": "pec_deck_reverse_fly",
+  "reverse fly (dumbbell)": "reverse_fly",
+  "rear delt fly": "reverse_fly",
+  "reverse fly": "reverse_fly",
+
+  // ── PULL / BICEPS ─────────────────────────────────────────────────────────
+  "preacher curl (ez bar)": "preacher_curls",
+  "preacher curl": "preacher_curls",
+  "ez bar preacher curl": "preacher_curls",
+
+  "hammer curl (dumbbell)": "hammer_curls",
+  "hammer curl": "hammer_curls",
+
+  "incline curl (dumbbell)": "incline_db_curl",
+  "incline dumbbell curl": "incline_db_curl",
+
+  "bicep curl (cable)": "cable_curl",
+  "cable bicep curl": "cable_curl",
+  "cable curl": "cable_curl",
+
+  // ── LEGS / QUADS ──────────────────────────────────────────────────────────
+  "leg press": "sl_leg_press_right",
+  "single leg press": "sl_leg_press_right",
+  "leg press (single leg)": "sl_leg_press_right",
+
+  "hack squat": "hack_squat_right",
+  "hack squat machine": "hack_squat_right",
+
+  "leg extension": "sl_leg_extension_right",
+  "leg extension (single leg)": "sl_leg_extension_right",
+  "single leg extension": "sl_leg_extension_right",
+
+  // ── LEGS / GLUTES + HAMSTRINGS ────────────────────────────────────────────
+  "glute bridge": "sl_glute_bridge_right",
+  "single leg glute bridge": "sl_glute_bridge_right",
+  "barbell glute bridge": "sl_glute_bridge_right",
+
+  "hip thrust (barbell)": "sl_hip_thrust_right",
+  "hip thrust": "sl_hip_thrust_right",
+  "barbell hip thrust": "sl_hip_thrust_right",
+  "single leg hip thrust": "sl_hip_thrust_right",
+
+  "leg curl (lying)": "prone_ham_curl_right",
+  "leg curl (prone)": "prone_ham_curl_right",
+  "lying leg curl": "prone_ham_curl_right",
+  "prone leg curl": "prone_ham_curl_right",
+  "hamstring curl": "prone_ham_curl_right",
+
+  "stability ball leg curl": "stab_ball_ham_curl_right",
+  "swiss ball leg curl": "stab_ball_ham_curl_right",
+  "stability ball hamstring curl": "stab_ball_ham_curl_right",
+
+  "nordic hamstring curl": "nordic_ham_curl",
+  "nordic curl": "nordic_ham_curl",
+
+  "calf raise": "standing_calf_raise_r",
+  "standing calf raise": "standing_calf_raise_r",
+  "seated calf raise": "standing_calf_raise_r",
+
+  // ── LEGS / ADDUCTION + ABDUCTION ──────────────────────────────────────────
+  "hip abduction (machine)": "side_lying_hip_abduction_left",
+  "hip abduction": "side_lying_hip_abduction_left",
+  "clamshell": "banded_clamshells",
+  "banded clamshell": "banded_clamshells",
+  "clamshells": "banded_clamshells",
+
+  // ── CORE ──────────────────────────────────────────────────────────────────
+  "plank": "forearm_plank_saw",
+  "forearm plank": "forearm_plank_saw",
+  "dead bug": "dead_bug_r_leg_only",
+  "hollow body hold": "hollow_body_hold",
+  "pallof press": "pallof_press_seated",
+  "bird dog": "bird_dog_prone_bench",
+  "bird-dog": "bird_dog_prone_bench",
+  "russian twist": "russian_twist_seated_bench",
+  "cable woodchop": "cable_woodchop_seated",
+  "side plank": "side_plank_r_side_down",
+  "mcgill curl up": "mcgill_curl_up",
+  "mcgill curl-up": "mcgill_curl_up",
+
+  // ── CARDIO ────────────────────────────────────────────────────────────────
+  "ski erg": "seated_skierg",
+  "skierg": "seated_skierg",
+  "rowing machine": "arm_ergometer",
+  "battle ropes": "seated_battle_ropes",
+};
+
+/** Normalize a Hevy exercise name for map lookup. */
+function normalizeHevyName(raw: string): string {
+  return raw
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+/**
+ * Look up a Hevy exercise name and return the NWB-Plan exercise id, or null
+ * if no mapping exists.
+ */
+export function findExerciseId(hevyName: string): string | null {
+  const key = normalizeHevyName(hevyName);
+  return HEVY_NAME_MAP[key] ?? null;
+}


### PR DESCRIPTION
## Summary
Imports Hevy workout history into \`workout-log:sessions\` so the SetTracker can prefill weights/reps from prior sessions. Fully client-side, offline-capable, no backend, no new npm deps.

- \`lib/hevy-name-map.ts\` — 100-entry \`HEVY_NAME_MAP\` keyed by lowercased Hevy exercise name → NWB-Plan exercise id. Covers most common gym vocabulary (bench/floor press, machine chest press, lat pulldown variants, leg press/hack squat/leg extension, hip thrust/glute bridge, ham curl variants, plus core: plank, dead bug, pallof press, etc.). \`findExerciseId(hevyName)\` does case-insensitive lookup with null fallback.
- \`lib/hevy-import.ts\` — \`parseHevyCsv(csvText)\` returns \`{ matched: WorkoutSession[]; skipped: { name; sets }[]; rawCount }\`. Pure-JS CSV parser handles quoted fields and escaped quotes. Groups rows by Workout # + Date into sessions; groups sets within session by exercise. Converts kg → lb (rounded to nearest 2.5 lb).
- \`components/hevy-import-panel.tsx\` — UI: file input, parse preview, confirmation panel (workouts/matched/skipped counts, expandable skipped list), Import / Cancel, success/error states.
- Mounted at the bottom of the **Equip tab** (after Gym Bag Essentials) — Equip is already the configuration/setup surface; one-time imports belong there.

## Caveats
- Hevy "lb" exports work if the column header is exactly \`Weight (lbs)\`; non-standard headers fall back to kg-conversion (visible from absurd prefilled weights, easy for user to spot).
- Re-imports append duplicate sessions by design (no Hevy ID dedupe — trust the user).
- Hevy custom/gym-specific exercise names are skipped and surfaced in the skipped list for review.

## Test plan
- [ ] Import a 5-row CSV; verify matched sessions land in \`workout-log:sessions\`.
- [ ] Verify skipped exercises display correctly.
- [ ] Import twice; verify duplicates land (no dedupe).
- [ ] After import, navigate to a matched exercise's SetTracker and verify weight/reps prefill from imported data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)