### PR TITLE
feat(api): scaffold exercise library backend on Neon Postgres

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -13,3 +13,25 @@ NEXTAUTH_URL=https://nfit.93.fyi
 # Vercel KV (placeholder — set up KV in Vercel dashboard)
 KV_REST_API_URL=
 KV_REST_API_TOKEN=
+
+# ============================================================================
+# Exercise library backend (Neon Postgres via Vercel Marketplace)
+# ============================================================================
+#
+# When you provision Neon via Vercel Marketplace these are auto-injected.
+# For local dev, run `vercel env pull .env.local` after linking the project.
+# `@vercel/postgres` reads POSTGRES_URL by default.
+#
+POSTGRES_URL=
+POSTGRES_PRISMA_URL=
+POSTGRES_URL_NON_POOLING=
+POSTGRES_USER=
+POSTGRES_HOST=
+POSTGRES_PASSWORD=
+POSTGRES_DATABASE=
+
+# Bearer token for write endpoints (POST/PATCH/DELETE on /api/exercises).
+# Generate with: openssl rand -hex 32
+# Example (DO NOT use this in prod):
+#   EXERCISE_API_TOKEN=cf35053ab4a5eafa156d6ea6969a9c4ba31c4e17aa682ce5290489f264298cc6
+EXERCISE_API_TOKEN=

--- a/app/api/exercises/[id]/route.ts
+++ b/app/api/exercises/[id]/route.ts
@@ -1,0 +1,123 @@
+/**
+ * /api/exercises/[id]
+ *
+ *   GET     — single exercise by id (public, cached 1h)
+ *   PATCH   — partial update (bearer-token authed)
+ *   DELETE  — remove (bearer-token authed)
+ *
+ * Path-param convention: `id` is the slug-style id from `lib/exercises.ts`,
+ * e.g. `barbell_floor_press`.  NOT the display name.
+ *
+ * Next.js 16 route signature: dynamic params come in as an awaitable
+ * `Promise<{ id: string }>`. (Was sync in Next 14, async in 15+.)
+ */
+
+import { NextResponse } from "next/server";
+import {
+  deleteExercise,
+  getExerciseById,
+  updateExercise,
+  type ExerciseUpdate,
+} from "@/lib/db";
+import { requireBearerToken } from "@/lib/api-auth";
+
+export const revalidate = 3600;
+
+const CACHE_HEADER = "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400";
+
+interface RouteCtx {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(_request: Request, ctx: RouteCtx) {
+  const { id } = await ctx.params;
+
+  try {
+    const ex = await getExerciseById(id);
+    if (!ex) {
+      return NextResponse.json(
+        { error: `Exercise "${id}" not found` },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(
+      { exercise: ex },
+      { headers: { "Cache-Control": CACHE_HEADER } },
+    );
+  } catch (err) {
+    console.error(`GET /api/exercises/${id} failed:`, err);
+    return NextResponse.json(
+      { error: "Failed to load exercise" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(request: Request, ctx: RouteCtx) {
+  const auth = requireBearerToken(request);
+  if (!auth.ok) return auth.response;
+
+  const { id } = await ctx.params;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400 },
+    );
+  }
+
+  if (!body || typeof body !== "object") {
+    return NextResponse.json(
+      { error: "Body must be a JSON object" },
+      { status: 400 },
+    );
+  }
+
+  // PATCH is partial — no required-field check.  Whatever's present
+  // overrides; everything else is preserved by `updateExercise`.
+  const patch = body as ExerciseUpdate;
+
+  try {
+    const updated = await updateExercise(id, patch);
+    if (!updated) {
+      return NextResponse.json(
+        { error: `Exercise "${id}" not found` },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json({ exercise: updated });
+  } catch (err) {
+    console.error(`PATCH /api/exercises/${id} failed:`, err);
+    return NextResponse.json(
+      { error: "Failed to update exercise" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(request: Request, ctx: RouteCtx) {
+  const auth = requireBearerToken(request);
+  if (!auth.ok) return auth.response;
+
+  const { id } = await ctx.params;
+
+  try {
+    const removed = await deleteExercise(id);
+    if (!removed) {
+      return NextResponse.json(
+        { error: `Exercise "${id}" not found` },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json({ ok: true, id });
+  } catch (err) {
+    console.error(`DELETE /api/exercises/${id} failed:`, err);
+    return NextResponse.json(
+      { error: "Failed to delete exercise" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/exercises/route.ts
+++ b/app/api/exercises/route.ts
@@ -1,0 +1,137 @@
+/**
+ * /api/exercises
+ *
+ *   GET   — full exercise library (public, cached 1h)
+ *   POST  — create exercise (bearer-token authed)
+ *
+ * Caching: GET sets `Cache-Control: public, max-age=3600, s-maxage=3600`
+ * AND uses `revalidate = 3600` so Next.js's data cache reuses the result
+ * across server invocations within the hour. This is the conservative
+ * choice — Cache Components / `cacheLife` are still stabilising in
+ * Next 16, and a plain `revalidate` value works on every Vercel runtime
+ * including Edge.  The MCP server can bust this with `revalidateTag` once
+ * we tag responses (Phase 1 — see docs/exercise-backend.md).
+ *
+ * Runtime: Node.js (default).  `@vercel/postgres` works in both Edge and
+ * Node, but we don't need Edge here and Node makes JSON.parse / large
+ * payloads easier to debug.
+ */
+
+import { NextResponse } from "next/server";
+import {
+  createExercise,
+  getAllExercises,
+  type ExerciseInput,
+} from "@/lib/db";
+import { requireBearerToken } from "@/lib/api-auth";
+
+// Cache the GET response for 1 hour at the framework layer.
+export const revalidate = 3600;
+
+const CACHE_HEADER = "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400";
+
+export async function GET() {
+  try {
+    const exercises = await getAllExercises();
+    return NextResponse.json(
+      { exercises },
+      {
+        headers: {
+          "Cache-Control": CACHE_HEADER,
+        },
+      },
+    );
+  } catch (err) {
+    console.error("GET /api/exercises failed:", err);
+    return NextResponse.json(
+      { error: "Failed to load exercises" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  const auth = requireBearerToken(request);
+  if (!auth.ok) return auth.response;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400 },
+    );
+  }
+
+  const validation = validateExerciseInput(body);
+  if (!validation.ok) {
+    return NextResponse.json({ error: validation.error }, { status: 400 });
+  }
+
+  try {
+    const created = await createExercise(validation.data);
+    return NextResponse.json({ exercise: created }, { status: 201 });
+  } catch (err) {
+    console.error("POST /api/exercises failed:", err);
+    return NextResponse.json(
+      { error: "Failed to create exercise" },
+      { status: 500 },
+    );
+  }
+}
+
+// --- validation -----------------------------------------------------------
+
+interface Valid<T> {
+  ok: true;
+  data: T;
+}
+interface Invalid {
+  ok: false;
+  error: string;
+}
+
+function validateExerciseInput(input: unknown): Valid<ExerciseInput> | Invalid {
+  if (!input || typeof input !== "object") {
+    return { ok: false, error: "Body must be a JSON object" };
+  }
+  const o = input as Record<string, unknown>;
+
+  for (const field of [
+    "id",
+    "name",
+    "category",
+    "setup",
+    "execution",
+    "nwbCues",
+    "why",
+    "safety",
+  ] as const) {
+    if (typeof o[field] !== "string" || (o[field] as string).length === 0) {
+      return { ok: false, error: `Field "${field}" must be a non-empty string` };
+    }
+  }
+  if (typeof o.rest !== "number") {
+    return { ok: false, error: 'Field "rest" must be a number' };
+  }
+  if (!["safe", "caution", "danger"].includes(o.safety as string)) {
+    return { ok: false, error: 'Field "safety" must be "safe" | "caution" | "danger"' };
+  }
+  if (!Array.isArray(o.requires) || !o.requires.every((x) => typeof x === "string")) {
+    return { ok: false, error: '"requires" must be string[]' };
+  }
+  if (!Array.isArray(o.swaps) || !o.swaps.every((x) => typeof x === "string")) {
+    return { ok: false, error: '"swaps" must be string[]' };
+  }
+  if (!Array.isArray(o.sets)) {
+    return { ok: false, error: '"sets" must be an array of [string, string] tuples' };
+  }
+  if (!o.constraints || typeof o.constraints !== "object") {
+    return { ok: false, error: '"constraints" must be an object' };
+  }
+
+  // We've type-checked the basics; cast through.  The DB enforces shape
+  // beyond this — e.g. JSONB will reject malformed values.
+  return { ok: true, data: o as unknown as ExerciseInput };
+}

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,221 @@
+-- ============================================================================
+-- NWB Exercise Library — Postgres Schema (Neon / Vercel Marketplace)
+-- ============================================================================
+--
+-- This schema mirrors the shape of `lib/exercises.ts` so the migration script
+-- in `scripts/migrate-exercises-to-db.ts` can load it mechanically. Modelling
+-- choices:
+--
+--   * `exercises` is the canonical row.  String-arrays whose only consumer is
+--     "render this with the exercise" (`requires`, `swaps`, `amp`) live as
+--     JSONB columns on the row — not lifted to junction tables.  We never
+--     query "exercises by required equipment" today; if/when we do we add a
+--     GIN index on the JSONB column.
+--   * `sets` and `constraints` are JSONB.  `sets` is `[[count, reps], ...]`
+--     and is a single nested literal in the source — denormalising would
+--     destroy the ordering and force two extra tables for negligible gain.
+--   * `machine_variants` IS lifted to its own table.  Variants have stable
+--     ids (`plate_loaded`, `pin_loaded`, ...) that may be referenced
+--     elsewhere (analytics, MCP search, swap-by-variant) and a per-row
+--     `superset` JSONB so the variant carries its own coaching cue.
+--   * `workouts`, `workout_exercises`, `core_finishers`, `schedule`, `phases`
+--     mirror the rest of `lib/exercises.ts`.  These are static structural
+--     data; they live in the same DB so the eventual MCP server can mutate
+--     a routine without touching code.
+--   * `lib/supplements.ts` (left-leg / core supplements) is intentionally
+--     LEFT OUT of the DB for Phase 0.  See docs/exercise-backend.md for the
+--     reasoning — those are tightly coupled to NWB safety invariants and
+--     change less than once per quarter, so static-import remains correct.
+--
+-- Idempotency: every CREATE uses IF NOT EXISTS so this file is safe to run
+-- against a fresh DB or one already migrated.
+-- ============================================================================
+
+-- ---- exercises ------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS exercises (
+  -- Slug-ish primary key.  Matches the `id` field in the TypeScript source
+  -- (e.g. `barbell_floor_press`).  Lower-snake.  PK is the natural choice
+  -- because the client already uses these strings as map keys.
+  id              TEXT PRIMARY KEY,
+
+  -- Display name.  Doubles as the lookup key in lib/exercises.ts (`EX[name]`)
+  -- so it must be unique.
+  name            TEXT NOT NULL UNIQUE,
+
+  category        TEXT NOT NULL,            -- "push" | "pull" | "legs" | "core" | "cardio" | ...
+  rest_seconds    INTEGER NOT NULL,
+  setup           TEXT NOT NULL,
+  execution       TEXT NOT NULL,
+  nwb_cues        TEXT NOT NULL,
+  why             TEXT NOT NULL,
+  safety          TEXT NOT NULL CHECK (safety IN ('safe', 'caution', 'danger')),
+
+  -- Optional scalars
+  visual          TEXT,                     -- ASCII art
+  diagram         TEXT,                     -- diagram registry key (e.g. "planche")
+  tempo           TEXT,                     -- e.g. "4-4-0"
+  phase           INTEGER,                  -- 1 | 2 | 3
+  tier            INTEGER,
+  cable_superset  BOOLEAN NOT NULL DEFAULT FALSE,
+
+  -- Required equipment ids (string[]).  Read together with the row.
+  -- ["barbell", "mat"]
+  requires        JSONB NOT NULL DEFAULT '[]'::jsonb,
+
+  -- Swap target names (string[]).  Read together with the row.
+  swaps           JSONB NOT NULL DEFAULT '[]'::jsonb,
+
+  -- Optional AMP progression strings (string[]).
+  amp             JSONB,
+
+  -- Set/rep tuples: [["4","5-6"], ["4","4-5"], ["5","3-5"]]
+  sets            JSONB NOT NULL,
+
+  -- Safety constraints object: { requiresIliopsoas, maxHipFlexion, requiresWeightBearing }
+  constraints     JSONB NOT NULL,
+
+  -- Audit
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS exercises_category_idx ON exercises (category);
+CREATE INDEX IF NOT EXISTS exercises_safety_idx   ON exercises (safety);
+CREATE INDEX IF NOT EXISTS exercises_phase_idx    ON exercises (phase);
+-- GIN on `requires` so a future query like "find exercises that need cables"
+-- is cheap.  Cost is small for 80 rows; future-proofs the API.
+CREATE INDEX IF NOT EXISTS exercises_requires_gin ON exercises USING GIN (requires);
+
+-- ---- machine_variants -----------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS machine_variants (
+  -- Synthetic surrogate key — lets us PATCH a single variant without name
+  -- collision concerns across exercises.
+  pk                BIGSERIAL PRIMARY KEY,
+
+  exercise_id       TEXT NOT NULL REFERENCES exercises (id) ON DELETE CASCADE,
+
+  -- Source-level id, e.g. "plate_loaded", "pin_loaded", "rogue_rack_barbell".
+  -- Unique within the exercise; not globally unique (different exercises
+  -- share "plate_loaded").
+  variant_id        TEXT NOT NULL,
+
+  label             TEXT NOT NULL,
+  icon              TEXT NOT NULL,
+  description       TEXT NOT NULL,
+
+  setup_cues        JSONB NOT NULL DEFAULT '[]'::jsonb,    -- string[]
+  variant_requires  JSONB,                                 -- string[] | null (overrides exercise.requires)
+  superset          JSONB,                                 -- VariantSuperset | null
+
+  -- Preserve source order so the UI's machine picker renders consistently.
+  position          INTEGER NOT NULL DEFAULT 0,
+
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  UNIQUE (exercise_id, variant_id)
+);
+
+CREATE INDEX IF NOT EXISTS machine_variants_exercise_idx ON machine_variants (exercise_id);
+
+-- ---- workouts -------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS workouts (
+  -- Workout key, e.g. "Push A", "Legs B".  Matches WORKOUTS map keys.
+  id          TEXT PRIMARY KEY,
+  title       TEXT NOT NULL,
+  icon        TEXT NOT NULL,
+  color       TEXT NOT NULL,
+  hevy_url    TEXT,
+  -- Per-workout removed/excluded exercises with reasons:
+  --   [{ "name": "Standing OHP", "reason": "Requires bilateral stance" }, ...]
+  removed     JSONB NOT NULL DEFAULT '[]'::jsonb,
+
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Ordered exercise list per workout (replaces WORKOUTS["Push A"].exercises[]).
+CREATE TABLE IF NOT EXISTS workout_exercises (
+  workout_id    TEXT NOT NULL REFERENCES workouts (id) ON DELETE CASCADE,
+  position      INTEGER NOT NULL,
+  -- Matches the source: workout.exercises is an array of exercise NAMES
+  -- (e.g. "Barbell Floor Press"), not ids.  We keep the same convention
+  -- so the migration is a pure copy.  FK on (name) -> exercises.name via
+  -- the unique constraint.
+  exercise_name TEXT NOT NULL REFERENCES exercises (name) ON UPDATE CASCADE ON DELETE RESTRICT,
+
+  PRIMARY KEY (workout_id, position)
+);
+
+CREATE INDEX IF NOT EXISTS workout_exercises_exercise_idx ON workout_exercises (exercise_name);
+
+-- ---- core_finishers -------------------------------------------------------
+
+-- CORE_FINISHERS: Record<workoutId, exerciseName[]>
+CREATE TABLE IF NOT EXISTS core_finishers (
+  workout_id    TEXT NOT NULL REFERENCES workouts (id) ON DELETE CASCADE,
+  position      INTEGER NOT NULL,
+  exercise_name TEXT NOT NULL REFERENCES exercises (name) ON UPDATE CASCADE ON DELETE RESTRICT,
+
+  PRIMARY KEY (workout_id, position)
+);
+
+-- ---- schedule -------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS schedule (
+  day_of_week  TEXT PRIMARY KEY,    -- "Mon", "Tue", ...
+  position     INTEGER NOT NULL,    -- 0-6 for ordering
+  workout_id   TEXT NOT NULL REFERENCES workouts (id) ON DELETE RESTRICT,
+  icon         TEXT NOT NULL,
+  color        TEXT NOT NULL
+);
+
+-- ---- phases ---------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS phases (
+  position     INTEGER PRIMARY KEY, -- 0, 1, 2 (preserves SCHED order)
+  weeks        TEXT NOT NULL,       -- "1-2", "3-4", "5-6"
+  name         TEXT NOT NULL,
+  color        TEXT NOT NULL,
+  description  TEXT NOT NULL
+);
+
+-- ---- equipment registry --------------------------------------------------
+
+-- Mirror of EQUIPMENT in lib/exercises.ts.  Stored as a flat lookup so the
+-- API can serve it alongside the exercise list (clients need both to render).
+CREATE TABLE IF NOT EXISTS equipment (
+  id        TEXT PRIMARY KEY,        -- "barbell", "dumbbells", ...
+  name      TEXT NOT NULL,
+  icon      TEXT NOT NULL,
+  category  TEXT NOT NULL            -- "weights" | "machines" | "functional" | ...
+);
+
+-- ---- updated_at trigger ---------------------------------------------------
+
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS exercises_updated_at        ON exercises;
+DROP TRIGGER IF EXISTS machine_variants_updated_at ON machine_variants;
+DROP TRIGGER IF EXISTS workouts_updated_at         ON workouts;
+
+CREATE TRIGGER exercises_updated_at
+  BEFORE UPDATE ON exercises
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER machine_variants_updated_at
+  BEFORE UPDATE ON machine_variants
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER workouts_updated_at
+  BEFORE UPDATE ON workouts
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/docs/exercise-backend.md
+++ b/docs/exercise-backend.md
@@ -1,0 +1,154 @@
+# Exercise Library Backend
+
+Scaffold for a Postgres-backed exercise library that the static client
+import (`lib/exercises.ts`) will eventually migrate onto. As of this PR
+the API exists alongside the static import — nothing in the client
+fetches from it yet.
+
+## Why a backend at all
+
+The exercise library is currently a 120 KB TypeScript constant. We want:
+
+1. **Remote mutation via MCP** — an MCP server (running on Vercel or
+   Cloudflare Workers) that mutates the library on Karl's behalf
+   ("add prone hip extension as a Legs B alternate", "swap the cue on
+   barbell floor press"). MCP cannot edit a TS file; it needs an API.
+2. **A single source of truth** when more than one device is editing.
+3. **Leaving offline-first behaviour intact** for the workout client.
+   The PWA's value proposition is that it loads under a squat rack
+   with two bars of reception. The DB must be additive — never on
+   the critical render path.
+
+## Stack
+
+| Layer       | Choice                              | Why |
+|-------------|-------------------------------------|-----|
+| Database    | Neon Postgres (Vercel Marketplace)  | Relational shape (exercises + variants + workouts + workout_exercises). Auto-provisioned env vars. Branchable for preview deploys. |
+| Client lib  | `@vercel/postgres`                  | Zero config when Marketplace-provisioned. Reads `POSTGRES_URL` lazily so `next build` doesn't need DB env. |
+| Migrations  | Plain `db/schema.sql` + tsx script  | We're at one schema rev. Bringing Drizzle/Prisma right now is overkill. Revisit when we hit migration #3. |
+| Auth (read) | None — public                       | Library data is non-sensitive. Cache-friendly. |
+| Auth (write)| Bearer token (`EXERCISE_API_TOKEN`) | Single tenant. Token lives in MCP server's env. Easy to rotate. |
+
+## Schema
+
+See `db/schema.sql`. Highlights:
+
+- `exercises` — one row per exercise, JSONB columns for `requires`,
+  `swaps`, `amp`, `sets`, `constraints`. JSONB because these are read
+  together with the row and the structure (e.g. nested set/rep tuples)
+  doesn't decompose cleanly into a relational shape.
+- `machine_variants` — separate table, FK to `exercises(id)`. Variants
+  have stable ids (`plate_loaded`, `pin_loaded`, `rogue_rack_barbell`)
+  that the MCP server may want to query/mutate independently.
+- `workouts` + `workout_exercises` — preserves ordered exercise list
+  per Push A / Pull A / etc.
+- `core_finishers`, `schedule`, `phases`, `equipment` — flat lookup
+  tables that mirror the corresponding `lib/exercises.ts` exports.
+- `lib/supplements.ts` is **not** modelled. The supplement / superset
+  data is tightly coupled to the NWB safety invariants (declared at
+  the top of that file) and is mutated less than once per quarter.
+  Keeping it static avoids the risk of an MCP write violating an
+  invariant. If/when that calculus changes, add `supplement_left_leg`
+  / `supplement_core` tables in a follow-up migration.
+
+## API surface
+
+All routes live under `app/api/exercises/`.
+
+| Method | Path                       | Auth   | Cache                   |
+|--------|----------------------------|--------|-------------------------|
+| GET    | `/api/exercises`           | public | 1h public + s-maxage     |
+| GET    | `/api/exercises/[id]`      | public | 1h public + s-maxage     |
+| POST   | `/api/exercises`           | bearer | n/a                     |
+| PATCH  | `/api/exercises/[id]`      | bearer | n/a                     |
+| DELETE | `/api/exercises/[id]`      | bearer | n/a                     |
+
+Bearer token is checked against `process.env.EXERCISE_API_TOKEN`. A
+mismatch returns 401; missing server-side env returns 503 (signals an
+ops issue rather than blaming the caller).
+
+## Caching
+
+- Framework: each GET handler exports `revalidate = 3600`, so Next.js
+  caches the rendered Response across function invocations within an
+  hour (per-region in Vercel).
+- HTTP: GET also sets `Cache-Control: public, max-age=3600,
+  s-maxage=3600, stale-while-revalidate=86400`. SWR gives us 24 h
+  of "old but usable" responses if the DB hiccups.
+- Why not Cache Components / `cacheLife`? Stable in Next 16 but the
+  ergonomics for tag-based invalidation from a write route are still
+  in flux. Plain `revalidate = 3600` works on every Vercel runtime
+  and is trivially replaceable with `revalidateTag('exercises')` once
+  we add the tag in Phase 1.
+
+## Migration plan
+
+### Phase 0 — this PR
+- Schema, DB client, API routes, migration script all exist.
+- The client (`components/workout-view.tsx`) still imports `EX` /
+  `WORKOUTS` directly from `lib/exercises.ts`.
+- Migration script has NOT been run. Postgres is NOT provisioned yet.
+- API will return 500 if hit (no DB) — that's fine; nothing calls it.
+
+### Phase 1 — provision + seed
+1. Provision Neon via Vercel Marketplace (`vercel storage add postgres`).
+2. `vercel env pull .env.local`.
+3. Apply schema: `psql "$POSTGRES_URL" -f db/schema.sql`.
+4. Run migration: `npx tsx scripts/migrate-exercises-to-db.ts`.
+5. Set `EXERCISE_API_TOKEN` in Vercel (preview + prod):
+   `vercel env add EXERCISE_API_TOKEN`. Generate with
+   `openssl rand -hex 32`.
+6. Verify GET `/api/exercises` from prod (`curl https://nfit.93.fyi/api/exercises | jq '.exercises | length'`)
+   matches `Object.keys(EX).length` from the source.
+7. Tag responses with `exercises` and switch the GET handlers to use
+   `revalidateTag` for Phase 2.
+
+### Phase 2 — client refactor (additive)
+Goal: client treats DB as truth, but offline UX never degrades.
+
+- On first load, fetch `/api/exercises`.
+  - If success: store in IndexedDB under `nwb-plan/exercise-library`.
+  - If fail (offline, 5xx, etc.): fall back to the static import
+    that's still bundled in. **Static import stays in the bundle as
+    a permanent fallback.** It's 120 KB; we can afford it.
+- On subsequent loads:
+  - Read from IndexedDB synchronously (block render on it).
+  - Background-fetch `/api/exercises` and update IndexedDB if the
+    response differs (compare hash or `updated_at` max).
+  - If the fetched library differs, surface a "Library updated —
+    refresh?" toast. Don't auto-refresh mid-workout.
+- Storage key: `exercise-library-v1`. Bump the suffix on schema-breaking
+  changes.
+
+### Phase 3 — live updates (optional)
+- After a write through the API (POST/PATCH/DELETE), the MCP server
+  could call a `/api/exercises/_invalidate` endpoint that bumps a
+  sentinel in Vercel KV (or Edge Config).
+- Service worker polls the sentinel every N minutes and pushes a
+  `MessageChannel` event to active clients telling them to re-fetch.
+- Defer until Phase 2 is in production and stable.
+
+## Operational notes
+
+- Migration script is upsert-only — it never deletes. To remove an
+  exercise that's been removed from the source, do it through the
+  DELETE API.
+- Backups: Neon has PITR by default. Snapshot before any schema
+  change.
+- Local dev: `vercel env pull .env.local`, then `npm run dev`. The
+  GET routes will work; writes need `EXERCISE_API_TOKEN` set in
+  `.env.local`.
+
+## Open TODOs before this is production-ready
+
+- [ ] Provision Neon Postgres via Vercel Marketplace.
+- [ ] Set `EXERCISE_API_TOKEN` in Vercel env (preview + prod).
+- [ ] Apply `db/schema.sql` against the provisioned database.
+- [ ] Run `scripts/migrate-exercises-to-db.ts`.
+- [ ] Smoke-test all 5 routes against prod.
+- [ ] Add `revalidateTag('exercises')` invocations in POST/PATCH/DELETE
+      and switch GET handlers to `unstable_cache` keyed on the tag.
+- [ ] Decide if `lib/supplements.ts` joins the DB (currently no).
+- [ ] Add an integration test (`e2e/test_exercise_api.py`) covering
+      GET happy + auth-fail + create→fetch round-trip.
+- [ ] Phase 2 client refactor (separate PR).

--- a/lib/api-auth.ts
+++ b/lib/api-auth.ts
@@ -1,0 +1,96 @@
+/**
+ * Bearer-token auth for the /api/exercises write endpoints.
+ *
+ * Token is provisioned via the `EXERCISE_API_TOKEN` env var (32+ bytes of
+ * `openssl rand -hex 32`).  Read at request time — never at module load —
+ * so missing-env doesn't crash `next build`.
+ *
+ * The MCP server that mutates the library will hold this token and send it
+ * as `Authorization: Bearer <token>`.  No multi-user model: this is a
+ * single-tenant private API.
+ */
+
+import { NextResponse } from "next/server";
+
+export interface AuthFailure {
+  ok: false;
+  response: NextResponse;
+}
+
+export interface AuthSuccess {
+  ok: true;
+}
+
+export type AuthResult = AuthSuccess | AuthFailure;
+
+/**
+ * Validate the `Authorization: Bearer <token>` header.
+ *
+ * Returns `{ ok: true }` on a match, `{ ok: false, response }` on
+ * any failure (missing header, malformed, mismatch, env unset).
+ *
+ * 401 on auth failures; 503 if the token is not configured server-side
+ * (signals "ops issue, not your fault" to the caller).
+ */
+export function requireBearerToken(request: Request): AuthResult {
+  const expected = process.env.EXERCISE_API_TOKEN;
+  if (!expected) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Server misconfigured: EXERCISE_API_TOKEN not set" },
+        { status: 503 },
+      ),
+    };
+  }
+
+  const header = request.headers.get("authorization");
+  if (!header) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Missing Authorization header" },
+        { status: 401 },
+      ),
+    };
+  }
+
+  const match = /^Bearer\s+(.+)$/i.exec(header);
+  if (!match) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Authorization header must be 'Bearer <token>'" },
+        { status: 401 },
+      ),
+    };
+  }
+
+  const provided = match[1].trim();
+  // Constant-time-ish compare.  We can't avoid the length check leaking
+  // length info but the token is 64 hex chars / fixed, so it's fine.
+  if (provided.length !== expected.length) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Invalid token" },
+        { status: 401 },
+      ),
+    };
+  }
+  let mismatch = 0;
+  for (let i = 0; i < provided.length; i++) {
+    mismatch |= provided.charCodeAt(i) ^ expected.charCodeAt(i);
+  }
+  if (mismatch !== 0) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Invalid token" },
+        { status: 401 },
+      ),
+    };
+  }
+
+  return { ok: true };
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,0 +1,370 @@
+/**
+ * Postgres client + typed query helpers for the exercise library.
+ *
+ * Why @vercel/postgres:
+ *   - Zero setup when Neon Postgres is provisioned via Vercel Marketplace.
+ *     The integration auto-injects POSTGRES_URL, POSTGRES_PRISMA_URL,
+ *     POSTGRES_URL_NON_POOLING, POSTGRES_USER, POSTGRES_HOST,
+ *     POSTGRES_PASSWORD, POSTGRES_DATABASE.  `@vercel/postgres` reads
+ *     POSTGRES_URL by default — nothing else to wire up.
+ *   - Connection pooling handled for us; safe in Edge + Node runtimes.
+ *   - Falls through to `pg` semantics when running locally with a plain
+ *     POSTGRES_URL (e.g. `postgres://localhost/nwb_plan`), so dev parity
+ *     is fine.
+ *
+ * Lazy initialization:
+ *   - We never read `process.env.POSTGRES_URL` at module load.  Instead the
+ *     `@vercel/postgres` `sql` template tag reads it lazily on first query.
+ *     This keeps `next build` happy in environments where the DB env vars
+ *     are deliberately absent (e.g. CI building a preview that doesn't talk
+ *     to the DB at runtime).
+ *
+ * The shape returned by getAllExercises / getExerciseById matches the
+ * `Exercise` type in `lib/exercises.ts` so the eventual client refactor is
+ * mechanical: drop the static import, swap in `await fetch('/api/exercises')`.
+ */
+
+import { sql } from "@vercel/postgres";
+
+// --- types ----------------------------------------------------------------
+// Mirror lib/exercises.ts WITHOUT importing it (to avoid pulling 120KB of
+// data into the API runtime).  Keep these in sync manually; the migration
+// script enforces the contract at run time.
+
+export interface ExerciseConstraints {
+  requiresIliopsoas: boolean;
+  maxHipFlexion: number;
+  requiresWeightBearing: boolean;
+}
+
+export interface VariantSuperset {
+  title: string;
+  sets: string;
+  instruction: string;
+  safety: string;
+  note?: string;
+}
+
+export interface MachineVariant {
+  id: string;
+  label: string;
+  icon: string;
+  description: string;
+  setupCues: string[];
+  superset?: VariantSuperset;
+  requires?: string[];
+}
+
+export type SafetyLevel = "safe" | "caution" | "danger";
+
+export interface Exercise {
+  id: string;
+  name: string;
+  category: string;
+  rest: number;
+  setup: string;
+  execution: string;
+  nwbCues: string;
+  why: string;
+  safety: SafetyLevel;
+  visual?: string;
+  diagram?: string;
+  tempo?: string;
+  phase?: number;
+  tier?: number;
+  cableSuperset?: boolean;
+  requires: string[];
+  swaps: string[];
+  amp?: string[];
+  sets: [string, string][];
+  constraints: ExerciseConstraints;
+  machineVariants?: MachineVariant[];
+}
+
+/**
+ * Input shape for create/update.  Same as Exercise minus auto-managed fields.
+ * Both include `machineVariants` because writes own that aggregate.
+ */
+export type ExerciseInput = Omit<Exercise, "id"> & { id: string };
+export type ExerciseUpdate = Partial<ExerciseInput>;
+
+// --- internal helpers -----------------------------------------------------
+
+/**
+ * Reassemble an Exercise from a joined exercises + machine_variants row set.
+ * Centralised so every read path returns the same shape.
+ */
+interface ExerciseRow {
+  id: string;
+  name: string;
+  category: string;
+  rest_seconds: number;
+  setup: string;
+  execution: string;
+  nwb_cues: string;
+  why: string;
+  safety: SafetyLevel;
+  visual: string | null;
+  diagram: string | null;
+  tempo: string | null;
+  phase: number | null;
+  tier: number | null;
+  cable_superset: boolean;
+  requires: string[];
+  swaps: string[];
+  amp: string[] | null;
+  sets: [string, string][];
+  constraints: ExerciseConstraints;
+}
+
+interface VariantRow {
+  exercise_id: string;
+  variant_id: string;
+  label: string;
+  icon: string;
+  description: string;
+  setup_cues: string[];
+  variant_requires: string[] | null;
+  superset: VariantSuperset | null;
+  position: number;
+}
+
+function rowToExercise(
+  row: ExerciseRow,
+  variants: VariantRow[],
+): Exercise {
+  const ex: Exercise = {
+    id: row.id,
+    name: row.name,
+    category: row.category,
+    rest: row.rest_seconds,
+    setup: row.setup,
+    execution: row.execution,
+    nwbCues: row.nwb_cues,
+    why: row.why,
+    safety: row.safety,
+    requires: row.requires,
+    swaps: row.swaps,
+    sets: row.sets,
+    constraints: row.constraints,
+  };
+
+  if (row.visual != null) ex.visual = row.visual;
+  if (row.diagram != null) ex.diagram = row.diagram;
+  if (row.tempo != null) ex.tempo = row.tempo;
+  if (row.phase != null) ex.phase = row.phase;
+  if (row.tier != null) ex.tier = row.tier;
+  if (row.cable_superset) ex.cableSuperset = true;
+  if (row.amp != null) ex.amp = row.amp;
+
+  if (variants.length > 0) {
+    ex.machineVariants = variants
+      .sort((a, b) => a.position - b.position)
+      .map((v): MachineVariant => {
+        const mv: MachineVariant = {
+          id: v.variant_id,
+          label: v.label,
+          icon: v.icon,
+          description: v.description,
+          setupCues: v.setup_cues,
+        };
+        if (v.variant_requires != null) mv.requires = v.variant_requires;
+        if (v.superset != null) mv.superset = v.superset;
+        return mv;
+      });
+  }
+
+  return ex;
+}
+
+// --- public API -----------------------------------------------------------
+
+/**
+ * Return every exercise in the library, with machine variants nested.
+ * Two queries; we stitch in JS rather than a heavy join to keep the JSONB
+ * payload manageable.
+ */
+export async function getAllExercises(): Promise<Exercise[]> {
+  const exRes = await sql<ExerciseRow>`
+    SELECT id, name, category, rest_seconds, setup, execution, nwb_cues,
+           why, safety, visual, diagram, tempo, phase, tier, cable_superset,
+           requires, swaps, amp, sets, constraints
+    FROM exercises
+    ORDER BY category, name
+  `;
+
+  const variantRes = await sql<VariantRow>`
+    SELECT exercise_id, variant_id, label, icon, description,
+           setup_cues, variant_requires, superset, position
+    FROM machine_variants
+    ORDER BY exercise_id, position
+  `;
+
+  const variantsByExercise = new Map<string, VariantRow[]>();
+  for (const v of variantRes.rows) {
+    const list = variantsByExercise.get(v.exercise_id) ?? [];
+    list.push(v);
+    variantsByExercise.set(v.exercise_id, list);
+  }
+
+  return exRes.rows.map((row) =>
+    rowToExercise(row, variantsByExercise.get(row.id) ?? []),
+  );
+}
+
+/**
+ * Look up one exercise by its slug-id (e.g. "barbell_floor_press").
+ * Returns null when not found.
+ */
+export async function getExerciseById(id: string): Promise<Exercise | null> {
+  const exRes = await sql<ExerciseRow>`
+    SELECT id, name, category, rest_seconds, setup, execution, nwb_cues,
+           why, safety, visual, diagram, tempo, phase, tier, cable_superset,
+           requires, swaps, amp, sets, constraints
+    FROM exercises
+    WHERE id = ${id}
+    LIMIT 1
+  `;
+
+  if (exRes.rows.length === 0) return null;
+
+  const variantRes = await sql<VariantRow>`
+    SELECT exercise_id, variant_id, label, icon, description,
+           setup_cues, variant_requires, superset, position
+    FROM machine_variants
+    WHERE exercise_id = ${id}
+    ORDER BY position
+  `;
+
+  return rowToExercise(exRes.rows[0], variantRes.rows);
+}
+
+/**
+ * Insert (or upsert) an exercise + its machine variants.
+ *
+ * Idempotent: re-running with the same id replaces the row's mutable
+ * columns and rewrites variant rows.  Used by both the migration script
+ * and the public POST route — same code path either way.
+ */
+export async function createExercise(data: ExerciseInput): Promise<Exercise> {
+  await sql`
+    INSERT INTO exercises (
+      id, name, category, rest_seconds, setup, execution, nwb_cues, why,
+      safety, visual, diagram, tempo, phase, tier, cable_superset,
+      requires, swaps, amp, sets, constraints
+    ) VALUES (
+      ${data.id},
+      ${data.name},
+      ${data.category},
+      ${data.rest},
+      ${data.setup},
+      ${data.execution},
+      ${data.nwbCues},
+      ${data.why},
+      ${data.safety},
+      ${data.visual ?? null},
+      ${data.diagram ?? null},
+      ${data.tempo ?? null},
+      ${data.phase ?? null},
+      ${data.tier ?? null},
+      ${data.cableSuperset ?? false},
+      ${JSON.stringify(data.requires)}::jsonb,
+      ${JSON.stringify(data.swaps)}::jsonb,
+      ${data.amp ? JSON.stringify(data.amp) : null}::jsonb,
+      ${JSON.stringify(data.sets)}::jsonb,
+      ${JSON.stringify(data.constraints)}::jsonb
+    )
+    ON CONFLICT (id) DO UPDATE SET
+      name           = EXCLUDED.name,
+      category       = EXCLUDED.category,
+      rest_seconds   = EXCLUDED.rest_seconds,
+      setup          = EXCLUDED.setup,
+      execution      = EXCLUDED.execution,
+      nwb_cues       = EXCLUDED.nwb_cues,
+      why            = EXCLUDED.why,
+      safety         = EXCLUDED.safety,
+      visual         = EXCLUDED.visual,
+      diagram        = EXCLUDED.diagram,
+      tempo          = EXCLUDED.tempo,
+      phase          = EXCLUDED.phase,
+      tier           = EXCLUDED.tier,
+      cable_superset = EXCLUDED.cable_superset,
+      requires       = EXCLUDED.requires,
+      swaps          = EXCLUDED.swaps,
+      amp            = EXCLUDED.amp,
+      sets           = EXCLUDED.sets,
+      constraints    = EXCLUDED.constraints
+  `;
+
+  // Replace the variants set — simplest correct semantics.  At ~5 variants
+  // max per exercise, the cost is negligible.
+  await sql`DELETE FROM machine_variants WHERE exercise_id = ${data.id}`;
+
+  if (data.machineVariants && data.machineVariants.length > 0) {
+    for (let i = 0; i < data.machineVariants.length; i++) {
+      const v = data.machineVariants[i];
+      await sql`
+        INSERT INTO machine_variants (
+          exercise_id, variant_id, label, icon, description,
+          setup_cues, variant_requires, superset, position
+        ) VALUES (
+          ${data.id},
+          ${v.id},
+          ${v.label},
+          ${v.icon},
+          ${v.description},
+          ${JSON.stringify(v.setupCues)}::jsonb,
+          ${v.requires ? JSON.stringify(v.requires) : null}::jsonb,
+          ${v.superset ? JSON.stringify(v.superset) : null}::jsonb,
+          ${i}
+        )
+      `;
+    }
+  }
+
+  const created = await getExerciseById(data.id);
+  if (!created) {
+    // Should be unreachable — we just wrote it.
+    throw new Error(`createExercise: row vanished after upsert (id=${data.id})`);
+  }
+  return created;
+}
+
+/**
+ * PATCH an exercise.  Only fields present in `patch` are updated.
+ *
+ * Variants are special-cased: if the patch includes `machineVariants`, we
+ * replace the entire set (matches the API contract of "update is a write
+ * for the field provided").  If absent, variants are untouched.
+ */
+export async function updateExercise(
+  id: string,
+  patch: ExerciseUpdate,
+): Promise<Exercise | null> {
+  const existing = await getExerciseById(id);
+  if (!existing) return null;
+
+  // Merge: anything not provided keeps its old value.
+  const merged: ExerciseInput = {
+    ...existing,
+    ...patch,
+    id, // never let the patch rewrite the primary key
+  };
+
+  // If the caller didn't pass machineVariants, preserve the existing ones
+  // by passing them through createExercise's variant-replacement path.
+  if (!("machineVariants" in patch)) {
+    merged.machineVariants = existing.machineVariants;
+  }
+
+  return createExercise(merged);
+}
+
+/**
+ * Delete an exercise.  Returns true if a row was removed.
+ * machine_variants rows cascade.
+ */
+export async function deleteExercise(id: string): Promise<boolean> {
+  const res = await sql`DELETE FROM exercises WHERE id = ${id}`;
+  return (res.rowCount ?? 0) > 0;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@types/node": "^25.5.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@vercel/postgres": "^0.10.0",
         "next": "^16.2.1",
         "next-auth": "^5.0.0-beta.30",
         "postcss": "^8.5.8",
@@ -614,6 +615,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@neondatabase/serverless": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-0.9.5.tgz",
+      "integrity": "sha512-siFas6gItqv6wD/pZnvdu34wEqgG3nSE6zWZdq5j2DEsa+VvX8i/5HXJOo06qrw5axPXn+lGCxeR+NLaSPIXug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pg": "8.11.6"
+      }
+    },
     "node_modules/@next/env": {
       "version": "16.2.1",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.1.tgz",
@@ -1031,11 +1041,23 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/pg": {
+      "version": "8.11.6",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.6.tgz",
+      "integrity": "sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^4.0.1"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1049,6 +1071,21 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@vercel/postgres": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@vercel/postgres/-/postgres-0.10.0.tgz",
+      "integrity": "sha512-fSD23DxGND40IzSkXjcFcxr53t3Tiym59Is0jSYIFpG4/0f0KO9SGtcp1sXiebvPaGe7N/tU05cH4yt2S6/IPg==",
+      "deprecated": "@vercel/postgres is deprecated. If you are setting up a new database, you can choose an alternate storage solution from the Vercel Marketplace. If you had an existing Vercel Postgres database, it should have been migrated to Neon as a native Vercel integration. You can find more details and the guide to migrate to Neon's SDKs here: https://neon.com/docs/guides/vercel-postgres-transition-guide",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@neondatabase/serverless": "^0.9.3",
+        "bufferutil": "^4.0.8",
+        "ws": "^8.17.1"
+      },
+      "engines": {
+        "node": ">=18.14"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.10",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
@@ -1059,6 +1096,20 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bufferutil": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/caniuse-lite": {
@@ -1536,6 +1587,17 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/oauth4webapi": {
       "version": "3.8.5",
       "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.5.tgz",
@@ -1543,6 +1605,54 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-numeric": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
+      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.1.0.tgz",
+      "integrity": "sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "pg-numeric": "1.0.2",
+        "postgres-array": "~3.0.1",
+        "postgres-bytea": "~3.0.0",
+        "postgres-date": "~2.1.0",
+        "postgres-interval": "^3.0.0",
+        "postgres-range": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/picocolors": {
@@ -1579,11 +1689,57 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postgres-array": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
+      "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
+      "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+      "license": "MIT",
+      "dependencies": {
+        "obuf": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
+      "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
+      "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-range": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
+      "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
+      "license": "MIT"
+    },
     "node_modules/preact": {
       "version": "10.24.3",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
       "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -1603,6 +1759,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1612,6 +1769,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -1764,6 +1922,27 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@vercel/postgres": "^0.10.0",
     "next": "^16.2.1",
     "next-auth": "^5.0.0-beta.30",
     "postcss": "^8.5.8",

--- a/scripts/migrate-exercises-to-db.ts
+++ b/scripts/migrate-exercises-to-db.ts
@@ -1,0 +1,159 @@
+// TODO: run with: npx tsx scripts/migrate-exercises-to-db.ts
+//
+// One-shot migration script that copies the static exercise library
+// (lib/exercises.ts) into Postgres.  Idempotent — safe to re-run.
+//
+// Prerequisites:
+//   1. Provision Neon Postgres via Vercel Marketplace; the integration
+//      auto-injects POSTGRES_URL into your Vercel env.
+//   2. `vercel env pull .env.local` so the script can connect locally.
+//   3. Apply schema:
+//        psql "$POSTGRES_URL" -f db/schema.sql
+//   4. Run this script:
+//        npx tsx scripts/migrate-exercises-to-db.ts
+//
+// Safety: this script ONLY upserts. It does NOT delete rows in the DB
+// that are absent from the source.  That's deliberate — gives us a
+// rollback runway during Phase 1 of the migration plan.
+
+import { sql } from "@vercel/postgres";
+
+import {
+  EX,
+  EQUIPMENT,
+  WORKOUTS,
+  CORE_FINISHERS,
+  SCHED,
+  PHASES,
+} from "../lib/exercises";
+import { createExercise, type ExerciseInput } from "../lib/db";
+
+async function migrate() {
+  console.log("=== NWB exercise library → Postgres ===");
+
+  if (!process.env.POSTGRES_URL) {
+    console.error(
+      "POSTGRES_URL not set.  Run `vercel env pull .env.local` first.",
+    );
+    process.exit(1);
+  }
+
+  // 1. exercises (+ machine_variants via createExercise's upsert)
+  const exercises = Object.values(EX);
+  console.log(`Upserting ${exercises.length} exercises…`);
+  for (const ex of exercises) {
+    const input: ExerciseInput = {
+      id: ex.id,
+      name: ex.name,
+      category: ex.category,
+      rest: ex.rest,
+      setup: ex.setup,
+      execution: ex.execution,
+      nwbCues: ex.nwbCues,
+      why: ex.why,
+      safety: ex.safety,
+      requires: ex.requires,
+      swaps: ex.swaps,
+      sets: ex.sets,
+      constraints: ex.constraints,
+    };
+    if (ex.visual !== undefined) input.visual = ex.visual;
+    if (ex.diagram !== undefined) input.diagram = ex.diagram;
+    if (ex.tempo !== undefined) input.tempo = ex.tempo;
+    if (ex.phase !== undefined) input.phase = ex.phase;
+    if (ex.tier !== undefined) input.tier = ex.tier;
+    if (ex.cableSuperset !== undefined) input.cableSuperset = ex.cableSuperset;
+    if (ex.amp !== undefined) input.amp = ex.amp;
+    if (ex.machineVariants !== undefined) {
+      input.machineVariants = ex.machineVariants;
+    }
+
+    await createExercise(input);
+    process.stdout.write(".");
+  }
+  process.stdout.write("\n");
+
+  // 2. equipment
+  console.log(`Upserting ${Object.keys(EQUIPMENT).length} equipment items…`);
+  for (const [id, item] of Object.entries(EQUIPMENT)) {
+    await sql`
+      INSERT INTO equipment (id, name, icon, category)
+      VALUES (${id}, ${item.name}, ${item.icon}, ${item.category})
+      ON CONFLICT (id) DO UPDATE SET
+        name = EXCLUDED.name,
+        icon = EXCLUDED.icon,
+        category = EXCLUDED.category
+    `;
+  }
+
+  // 3. workouts (+ workout_exercises)
+  console.log(`Upserting ${Object.keys(WORKOUTS).length} workouts…`);
+  for (const [id, w] of Object.entries(WORKOUTS)) {
+    await sql`
+      INSERT INTO workouts (id, title, icon, color, hevy_url, removed)
+      VALUES (
+        ${id},
+        ${w.title},
+        ${w.icon},
+        ${w.color},
+        ${w.hevy ?? null},
+        ${JSON.stringify(w.removed)}::jsonb
+      )
+      ON CONFLICT (id) DO UPDATE SET
+        title    = EXCLUDED.title,
+        icon     = EXCLUDED.icon,
+        color    = EXCLUDED.color,
+        hevy_url = EXCLUDED.hevy_url,
+        removed  = EXCLUDED.removed
+    `;
+
+    await sql`DELETE FROM workout_exercises WHERE workout_id = ${id}`;
+    for (let i = 0; i < w.exercises.length; i++) {
+      await sql`
+        INSERT INTO workout_exercises (workout_id, position, exercise_name)
+        VALUES (${id}, ${i}, ${w.exercises[i]})
+      `;
+    }
+  }
+
+  // 4. core_finishers
+  console.log("Upserting core finishers…");
+  for (const [workoutId, names] of Object.entries(CORE_FINISHERS)) {
+    await sql`DELETE FROM core_finishers WHERE workout_id = ${workoutId}`;
+    for (let i = 0; i < names.length; i++) {
+      await sql`
+        INSERT INTO core_finishers (workout_id, position, exercise_name)
+        VALUES (${workoutId}, ${i}, ${names[i]})
+      `;
+    }
+  }
+
+  // 5. schedule
+  console.log("Upserting schedule…");
+  await sql`DELETE FROM schedule`;
+  for (let i = 0; i < SCHED.length; i++) {
+    const day = SCHED[i];
+    await sql`
+      INSERT INTO schedule (day_of_week, position, workout_id, icon, color)
+      VALUES (${day.d}, ${i}, ${day.t}, ${day.i}, ${day.c})
+    `;
+  }
+
+  // 6. phases
+  console.log("Upserting phases…");
+  await sql`DELETE FROM phases`;
+  for (let i = 0; i < PHASES.length; i++) {
+    const p = PHASES[i];
+    await sql`
+      INSERT INTO phases (position, weeks, name, color, description)
+      VALUES (${i}, ${p.weeks}, ${p.name}, ${p.color}, ${p.desc})
+    `;
+  }
+
+  console.log("✓ migration complete");
+}
+
+migrate().catch((err) => {
+  console.error("Migration failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
**Scaffold-only PR.** API + DB schema + migration script + auth + caching strategy land here. The DB is NOT yet provisioned, the migration is NOT yet run, and the client still uses the static \`lib/exercises.ts\` — that's deliberate. This PR establishes the contract so the MCP server (next PR) and client offline-first refactor (later) can build on it.

## What's in the box
- **DB schema** (\`db/schema.sql\`) — 8 tables modeling \`exercises\` (with JSONB for \`requires\`/\`swaps\`/\`amp\`/\`sets\`/\`constraints\`), \`machine_variants\` (lifted out so MCP can mutate per-variant), \`workouts\`, \`workout_exercises\`, \`core_finishers\`, \`schedule\`, \`phases\`, \`equipment\`. \`lib/supplements.ts\` deliberately stays static (safety-invariant-coupled).
- **DB client** (\`lib/db.ts\`) — \`@vercel/postgres\` wrapper with typed query helpers (\`getAllExercises\`, \`getExerciseById\`, \`createExercise\`, \`updateExercise\`, \`deleteExercise\`). Lazy-init so \`next build\` works without DB env present.
- **API routes** — \`GET /api/exercises\`, \`GET /api/exercises/[id]\` (public, \`Cache-Control: public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400\`); \`POST/PATCH/DELETE\` (bearer-token authed via \`EXERCISE_API_TOKEN\`). \`export const revalidate = 3600\`.
- **Auth** (\`lib/api-auth.ts\`) — \`requireBearerToken(request)\` reads env per-request; constant-time compare; 503 if env unset, 401 if header bad.
- **Migration script** (\`scripts/migrate-exercises-to-db.ts\`) — reads \`lib/exercises.ts\` constants, idempotent upsert. NOT yet run.
- **Offline-first plan** (\`docs/exercise-backend.md\`) — Phase 0 (this PR) → Phase 1 (provision + migrate) → Phase 2 (client refactor with IndexedDB) → Phase 3 (SW push).
- **\`.env.example\`** documents \`POSTGRES_URL\` and \`EXERCISE_API_TOKEN\` (with \`openssl rand -hex 32\` hint).
- New dep: \`@vercel/postgres@^0.10.0\`.

## Production-readiness TODOs (next PRs)
1. Provision Neon Postgres via Vercel Marketplace (\`vercel storage add postgres\`).
2. Set \`EXERCISE_API_TOKEN\` in Vercel env (preview + prod).
3. \`vercel env pull .env.local\` → \`psql "$POSTGRES_URL" -f db/schema.sql\`.
4. Run \`npx tsx scripts/migrate-exercises-to-db.ts\`.
5. Smoke-test all 5 routes against prod.
6. Switch GETs to \`unstable_cache\` keyed on \`'exercises'\` tag; add \`revalidateTag('exercises')\` in writes.
7. \`e2e/test_exercise_api.py\` (GET happy + auth-fail + create→fetch round-trip).
8. Phase 2 client refactor (separate PR).

## Test plan
- [ ] \`npx tsc --noEmit\` clean.
- [ ] \`npm run build\` succeeds without DB env present (lazy-init verified).
- [ ] After Marketplace provisioning, schema apply + migrate, GET round-trip works.
- [ ] Auth: PATCH with no/bad token returns 401; with correct token returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)