### PR TITLE
docs(pwb): research deliverable — 25 PWB-safe exercises for Phase 4

### DIFF
--- a/docs/pwb-phase-exercises.md
+++ b/docs/pwb-phase-exercises.md
@@ -1,0 +1,563 @@
+# PWB Phase Exercise List — Phase 4 (Weeks 7–8)
+
+> **Status:** Draft for PT review. **Do not** add to `lib/exercises.ts` or expose
+> in the app until the user's PT signs off on each exercise *and* the radiologic
+> evidence of healing on the next MRI permits weight bearing.
+>
+> **Diagnosis context:** Left femoral neck stress fracture, **compression-sided
+> (inferior-medial)** — the lower-risk pattern, consistent with progressive PWB
+> reintroduction once cleared. Bilateral FAI + labral tears (hip flexion <90°
+> bilaterally). Bilateral proximal hamstring tendinosis. ZERO active left hip
+> flexion against gravity (iliopsoas compresses the healing fracture site).
+>
+> **Phase 4 goal:** Bridge from 8 weeks of strict NWB to symmetric bilateral
+> stance, gait, and gym-floor work — without rebooking surgery. Pain-free
+> graded loading, not "push through it."
+
+---
+
+## Hard NO-GO list (carries forward from Phase 1–3)
+
+These remain contraindicated through Phase 4. Cross-check every new exercise
+below against this list.
+
+| Removed exercise | Reason |
+|---|---|
+| Active SLR (left) | Iliopsoas compresses fracture |
+| Hanging leg raises (any) | Bilateral iliopsoas + >90° hip flexion |
+| Standard Navasana / V-ups | Bilateral hip flexor against gravity |
+| Standard Bird-Dog quadruped | FAI + femoral neck loading in flexion |
+| Seated Hamstring Curl | Compresses ischial tuberosity (tendinosis) |
+| Deep RDLs | Eccentric load too heavy for tendinosis |
+| Pistol Squats / Bulgarian Split Squat | Hip flexion >90°, deep labral load |
+| Nordic Hamstring Curl | Eccentric load too heavy until Phase 5+ |
+| Standing OHP / freestanding dips | Bilateral stance + balance demands |
+| Deep lunges, Cossack squats, deep step-ups | Hip flexion >90° |
+
+---
+
+## Universal stop signals (every exercise below)
+
+Stop *immediately* and report to PT if any of the following occur:
+
+- Sharp groin or anterior hip pain (any intensity) on the left
+- Pain >2/10 in the left hip during loading
+- Pain that lingers >2 hours after the session
+- New limp or antalgic gait that wasn't present at session start
+- Night pain after the session
+- Mechanical clicking, locking, or "give-way" sensation
+
+Pain-during-exercise target: **0–2/10 NRS** in the left hip; **0–3/10**
+elsewhere (per Hydroworx / Coyner femoral protocol guidance).
+
+---
+
+## Summary table (21 exercises, 8 categories)
+
+| # | Exercise | Category | PWB Level | Equipment | Sets × Reps |
+|---|---|---|---|---|---|
+| 1 | Deep-Water Running (vest) | Aquatic | Effective ~0% BW | Pool ≥6 ft, AquaJogger vest | 3 × 5 min @ RPE 5 |
+| 2 | Chest-Deep Aqua Walking (forward / backward / side) | Aquatic | ~50–55% BW | Pool, chest-deep | 2 × 3 min each direction |
+| 3 | Aqua Mini-Squats (rail-supported) | Aquatic | ~50% BW | Pool, rail | 3 × 10 |
+| 4 | Aqua Hip Abduction / Adduction (standing) | Aquatic | ~50% BW | Pool, rail | 3 × 12 each side |
+| 5 | Flutter-Kick with Pool Buoy (prone, board) | Aquatic | 0% BW | Pool, kickboard, ankle buoy | 4 × 30 sec |
+| 6 | AlterG Walking — graded protocol | Anti-gravity | 25% → 75% BW | AlterG treadmill | 2 × 8 min @ 2.0–2.5 mph |
+| 7 | AlterG Heel-Toe Cadence Drill | Anti-gravity | 50% BW | AlterG treadmill | 2 × 5 min |
+| 8 | TRX-Assisted Squat (bilateral, partial depth) | Land squat | Any (unloads via arms) | TRX, anchor | 3 × 8, hip flexion ≤80° |
+| 9 | TRX-Assisted Reverse Lunge (right leg back, left in front) | Land squat | ~50% (modified) | TRX | 3 × 8 (right leg working) |
+| 10 | Counterbalanced Box Squat (low box, hands forward) | Land squat | Bilateral, partial | Plyo box 18–20 in, 5 lb plate | 3 × 10 |
+| 11 | Wall Sit (60° → 75° → 90° progression) | Land squat | Bilateral | Wall, optional small ball | 3 × 20–45 sec |
+| 12 | TRX-Assisted Step-Down (forward, low box) | Land squat | Right leg working | TRX, 4-in box | 3 × 8 right leg |
+| 13 | Heel-to-Toe Tandem Walk | Gait drill | FWB once cleared | Floor strip, mat | 3 × 10 steps |
+| 14 | Marching in Place (PWB %) | Gait drill | 25–75% BW | AlterG OR scale-in-mirror | 2 × 30 sec each leg |
+| 15 | Single-Leg Stance Progression (R → L on floor → L on foam) | Gait drill | Any | Balance pad, wall for safety | 3 × 30 sec each side |
+| 16 | Banded Clamshells (Level 4 — long lever) | Glute med | NWB-compatible | Mini-band, mat | 3 × 12 each side |
+| 17 | Side Plank with Top-Leg Hip Abduction (R side down) | Glute med | NWB-compatible | Mat | 3 × 8 reps, 5-sec hold |
+| 18 | Lateral Band Walk (semi-squat, ~30° knee/hip) | Glute med | Bilateral, partial | Mini-band at ankles | 3 × 10 steps each direction |
+| 19 | Single-Leg Bridge (right leg, knee-extended progression) | Eccentric ham | Right limb only | Mat, optional 5 lb plate | 3 × 8 right leg |
+| 20 | Reverse Treadmill Walking | Eccentric ham | 0% incline first | Treadmill (or AlterG) | 2 × 3 min @ 1.5–2.0 mph |
+| 21 | Supine Bent-Knee Heel Slides (right leg only) | Hip flexor retraining | Floor (no gravity) | Mat, towel under heel | 3 × 10 right leg |
+| 22 | Standing Banded Hip Flexion <60° (right leg) | Hip flexor retraining | Bilateral stance, supported | Cable column / band, anchor low | 3 × 12 right leg |
+| 23 | Quadruped Hip Flexion Iso (right leg, hand-supported torso) | Hip flexor retraining | Quadruped, modified | Mat, bench for forearms | 3 × 8-sec holds, right only |
+| 24 | Recumbent Bike — Resistance Progression | Cycling | 0% standing BW | Recumbent stationary bike | 15–25 min, RPE 5 |
+| 25 | Upright Stationary Bike — High-Saddle Spin | Cycling | Bilateral, low compression | Upright bike, saddle ≥ "tall" | 10–15 min, light gear |
+
+**Total: 25 specific exercises.** (Target was 15–25; landed at 25 to fully cover
+all 8 categories with progressions.)
+
+---
+
+## Expanded sections
+
+### CATEGORY 1 — Aquatic exercises (5)
+
+Aquatic work is the workhorse of Phase 4. Buoyancy reduces ground reaction
+forces by ~50% at chest-deep and ~85–90% at neck-deep
+([Hydroworx](https://www.hydroworx.com/blog/broken-femur-rehabilitation/),
+[Sport Med Aquatics](https://sportmed.com/aquatics/)). It is the safest way
+to reintroduce gait mechanics, bilateral stance, and reactive balance with
+minimal axial load on the femoral neck.
+
+#### 1. Deep-Water Running (vest)
+
+- **PWB level:** Effective ~0% BW (feet do not touch bottom — vest suspends body)
+- **Equipment:** Pool ≥6 ft deep; AquaJogger / Speedo flotation vest; optional resistance fins
+- **Setup:** Vest on chest, in deep end. Body remains vertical, head out of water, no foot contact with bottom.
+- **Execution:** Run with high knees (kept ≤80° hip flexion on the left), reciprocating arm swing, ~80–100 cadence/min. 4-sec breath cycle.
+- **Sets × reps:** 3 × 5 min at RPE 5/10. Walk-jog cadence first 2 sessions, then steady jog cadence.
+- **Rationale:** Cardiovascular base + gait pattern reactivation without axial load. Standard for stress fracture rehab ([PMC review](https://pmc.ncbi.nlm.nih.gov/articles/PMC10749698/)).
+- **Safety / stop on:** Any left groin pain. Limit knee drive — left thigh stays below 80° hip flexion.
+- **Hip flexion <90°:** YES — actively cap left knee drive at 80°.
+- **Iliopsoas note:** Hip flexion in water is buoyancy-assisted, *not* loaded against gravity. The fluid resistance is mild and concentric only on the way up; gravity is neutralized. Acceptable.
+
+#### 2. Chest-Deep Aqua Walking (forward / backward / lateral)
+
+- **PWB level:** ~50–55% BW (chest-deep) — [Hydroworx data](https://www.hydroworx.com/blog/broken-femur-rehabilitation/)
+- **Equipment:** Pool, chest-deep depth (~xiphoid level)
+- **Setup:** Stand chest-deep, arms relaxed at surface, posture upright.
+- **Execution:** Walk forward heel-to-toe x 1 length; turn, walk backward x 1 length (toe-then-heel); side-step x 1 length each direction. Slow tempo, full stance phase per step.
+- **Sets × reps:** 2 × 3 min in each direction (~6 lengths of a small therapy pool).
+- **Rationale:** Reintroduces bilateral stance + heel strike at half body weight. Backward walking emphasizes posterior chain loading. ([Ivy Rehab aquatic](https://ivyrehab.com/health-resources/physical-therapy/aquatic-therapy-exercises/))
+- **Safety / stop on:** Any limp pattern in water. If you notice yourself favoring the right leg, depth is too shallow — go deeper.
+- **Hip flexion <90°:** YES (walking gait is ~30° max hip flexion).
+- **Iliopsoas note:** Buoyancy assists hip flexion (drag is the resistance, not gravity). Acceptable.
+
+#### 3. Aqua Mini-Squats (rail-supported)
+
+- **PWB level:** ~50% BW at chest-deep
+- **Equipment:** Pool, chest-deep, with edge / rail
+- **Setup:** Face the pool wall, light fingertip contact on rail. Feet shoulder-width.
+- **Execution:** Squat to **partial depth (~60° knee flexion, hip flexion ≤80°)**. 3-sec down, pause 1 sec, 2-sec up. Hands assist as needed.
+- **Sets × reps:** 3 × 10
+- **Rationale:** Bilateral squat pattern at half BW + tactile cue from hands on rail to manage load distribution.
+- **Safety / stop on:** Hip pinch at depth — back off ROM. Asymmetric loading visible in mirror.
+- **Hip flexion <90°:** YES — explicit ≤80° cap.
+- **Iliopsoas note:** Closed-chain squatting is glute/quad dominant; iliopsoas demand minimal at <80° flexion in upright spine.
+
+#### 4. Aqua Hip Abduction / Adduction (standing)
+
+- **PWB level:** ~50% BW (chest-deep)
+- **Equipment:** Pool, rail for support
+- **Setup:** Stand chest-deep, fingertips on rail, weight on stance leg.
+- **Execution:** Abduct working leg ~30° from midline; control return to neutral (don't slam). 2-sec out, 2-sec in. Repeat for adduction (across midline ~10°). Knee stays straight, no hip flexion.
+- **Sets × reps:** 3 × 12 each side (do right side first as control, then left)
+- **Rationale:** Glute med activation through frontal plane, water resistance is concentric in both directions. Safe even on the left because the leg moves laterally — no flexion-against-gravity component.
+- **Safety / stop on:** Any anterior hip pain. If left side feels weaker, that's expected — keep load light.
+- **Hip flexion <90°:** YES (zero flexion).
+- **Iliopsoas note:** Pure abd/add — iliopsoas not engaged. Safe on left.
+
+#### 5. Flutter-Kick with Pool Buoy
+
+- **PWB level:** 0% BW
+- **Equipment:** Kickboard (arms), buoy clamped between thighs OR ankle buoy on left leg only
+- **Setup:** Prone (face down) with kickboard, body horizontal, eyes down. (Alternatively supine if neck issues.)
+- **Execution:** Small flutter kicks (8–12 in amplitude) from the hip. Knees mostly straight. Steady tempo.
+- **Sets × reps:** 4 × 30 sec
+- **Rationale:** Posterior chain (glute/ham) endurance + horizontal loading of the femur (parallel to long axis, not axial). Standard component of femoral stress fracture protocols ([Coyner protocol](https://www.drcoyner.com/pdf/femoral-stress-fracture-protocol-pt-version.pdf)).
+- **Safety / stop on:** Any hip pain. If pain on left, switch to right-leg-only kick with left leg passive.
+- **Hip flexion <90°:** YES (kicks are ~10–20° hip range).
+- **Iliopsoas note:** Prone position eliminates gravity demand on iliopsoas. Acceptable.
+
+---
+
+### CATEGORY 2 — Anti-gravity treadmill (Alter-G) (2)
+
+The AlterG provides **1% increment unweighting from 100% down to 20% BW**
+([source](https://rxphysicaltherapy.com/physical-therapy-treatments/alterg-anti-gravity-treadmill/)).
+For femoral neck stress fractures specifically, the AlterG is most useful for
+gait quality drilling, not maximal stress recreation — **bone adapts
+site-specifically**, so the displayed BW% is a simplification
+([Running Mate analysis](https://runningmatekc.com/2020-4-17-antigravity-treadmills-and-stress-fractures-do-they-help/)).
+
+> **Availability:** Confirm with the user's PT clinic whether AlterG access is
+> available. If not, substitute these two exercises with treadmill walking
+> with 25–50% BW load offload via overhead-rail harness, or skip and rely on
+> aqua + land progressions.
+
+#### 6. AlterG Walking — graded BW% protocol
+
+- **PWB level:** Start 25% BW (week 7 day 1) → progress to 75% BW (week 8 day end), pending pain-free response
+- **Equipment:** AlterG anti-gravity treadmill
+- **Setup:** Calibrate harness shorts. Start: 2.0 mph, 0% incline, 25% BW.
+- **Execution:** Heel-toe walk gait, even cadence both sides. Symmetric arm swing. 2-min ramp, 6 min steady, 1 min ramp-down.
+- **Sets × reps:** 2 × 8 min (split into two AM/PM sessions on session days). Increase 5% BW per session if pain-free; **do not exceed +10% BW per week**.
+- **Rationale:** Graded reintroduction of axial load on femoral neck. Allows micro-controlled return without surgical risk ([PMC RCT protocol](https://pmc.ncbi.nlm.nih.gov/articles/PMC5348747/)).
+- **Safety / stop on:** Any new limp visible in mirror or felt. Any anterior hip pain >1/10. Stop and reduce BW% by 10% next session.
+- **Hip flexion <90°:** YES (walking is 30–40° max).
+- **Iliopsoas note:** Closed-chain gait — iliopsoas demand minimal during walking. Safe.
+
+#### 7. AlterG Heel-Toe Cadence Drill
+
+- **PWB level:** 50% BW
+- **Equipment:** AlterG treadmill, mirror
+- **Setup:** 1.8 mph, 0% incline, 50% BW. Mirror in front for self-correction.
+- **Execution:** Exaggerated heel-strike → mid-foot → toe-off cadence. Slow 60–70 step/min. Conscious symmetry.
+- **Sets × reps:** 2 × 5 min
+- **Rationale:** Gait quality > volume. Re-patterns the heel-strike that's atrophied during NWB. Used in joint replacement protocols ([HipKnee Info](https://hipkneeinfo.org/wp-content/uploads/2024/06/Gait-Training-Jan-2021.pdf)).
+- **Safety / stop on:** If left side trends to flat-foot strike, reduce speed.
+- **Hip flexion <90°:** YES.
+- **Iliopsoas note:** Walking gait — minimal iliopsoas demand. Safe.
+
+---
+
+### CATEGORY 3 — Land-based PWB squat / step variations (5)
+
+Closed-chain land work begins **only after AlterG 75% BW or chest-deep aqua
+walking is pain-free for 5+ consecutive sessions**. The TRX is the key tool —
+it lets the upper body offload up to 30–40% of the squat load via the arms,
+giving an effective PWB squat without requiring a treadmill harness.
+
+#### 8. TRX-Assisted Squat (bilateral, partial depth)
+
+- **PWB level:** Bilateral, ~60–70% BW per leg (TRX offloads via arms)
+- **Equipment:** TRX or rings, anchor at ~7 ft
+- **Setup:** Face the anchor. Hold straps with arms extended at chest level. Feet shoulder-width, slight toe-out.
+- **Execution:** Lean back ~15° into the straps. Squat to **80° hip flexion max** (thighs above parallel). 3-sec down, pause 1, drive up via arms + legs. Even foot pressure.
+- **Sets × reps:** 3 × 8
+- **Rationale:** Reintroduces bilateral squat pattern with offloaded arms taking ~30% of the load. Validated rehab tool ([TRX Rehab guidance](https://thebarbellphysio.com/best-trx-rehab-exercises/)).
+- **Safety / stop on:** Asymmetric foot pressure — visible left lift = stop. Hip pinch at depth.
+- **Hip flexion <90°:** YES (explicit 80° cap).
+- **Iliopsoas note:** Closed-chain bilateral squat; iliopsoas not loaded against gravity.
+
+#### 9. TRX-Assisted Reverse Lunge (right leg back, left front)
+
+- **PWB level:** Working leg = right (back leg drops); left = stable front foot, ~50% BW
+- **Equipment:** TRX
+- **Setup:** Face the TRX anchor. Left foot forward (planted, light load), right foot back (working). Hands on straps.
+- **Execution:** Right knee drops toward floor (not touching), left knee bends to **≤80° flexion**. Use straps to manage descent. Drive up through *front* (left) heel + arms.
+- **Sets × reps:** 3 × 8 (working the right leg).
+- **Rationale:** Builds right-side strength and **uses left leg in stance only** (no deep flexion, no propulsion). Replaces the contraindicated Bulgarian split squat with a left-front variant.
+- **Safety / stop on:** Left knee tracking inward; left hip pinch.
+- **Hip flexion <90°:** YES (left front leg ≤80°).
+- **Iliopsoas note:** Left leg is in *stance* (closed-chain), not flexing against gravity. Right leg flexion is fine. Acceptable.
+
+#### 10. Counterbalanced Box Squat (low box, hands forward)
+
+- **PWB level:** Bilateral, partial depth
+- **Equipment:** 18–20 in plyo box; 5 lb plate held arms-extended forward
+- **Setup:** Stand in front of box. Hold plate at shoulder height with arms extended forward (counterbalance shifts COM forward, allowing more hip-back without flexion).
+- **Execution:** Sit back to box, **glute taps box** (no full sit). 80° hip flexion max. 3-sec eccentric.
+- **Sets × reps:** 3 × 10
+- **Rationale:** Counterbalance allows shallower hip flexion while still recruiting glutes/quads. Common ACL-progression staple ([P]Rehab](https://theprehabguys.com/step-ups/)).
+- **Safety / stop on:** Box too low (ROM too deep) — raise it.
+- **Hip flexion <90°:** YES (explicit cap).
+- **Iliopsoas note:** Closed-chain; minimal iliopsoas.
+
+#### 11. Wall Sit Progression (60° → 75° → 90° knee angle)
+
+- **PWB level:** Bilateral, equal load
+- **Equipment:** Smooth wall; optional small ball between knees for adduction co-activation
+- **Setup:** Back flat against wall, feet ~18 in from wall.
+- **Execution:** Slide down to **60° knee flexion** (NOT 90° to start — patellofemoral force scales nonlinearly with angle, [PubMed](https://pubmed.ncbi.nlm.nih.gov/19276845/)). Hold, breathe, no breath-hold.
+- **Sets × reps:**
+  - Week 7 day 1: 60° × 20 sec × 3 sets
+  - Week 7 day 4: 60° × 30 sec × 3 sets
+  - Week 8 day 1: 75° × 20 sec × 3 sets
+  - Week 8 day 4: 90° × 20 sec × 3 sets (only if pain-free at 75°)
+- **Rationale:** Isometric quad strength + bilateral load tolerance. Lower knee angles minimize joint compression early ([PubMed](https://pubmed.ncbi.nlm.nih.gov/19276845/)).
+- **Safety / stop on:** Asymmetric foot pressure (use bathroom scale under each foot to verify even loading), any anterior hip pain.
+- **Hip flexion <90°:** YES at 60° and 75°. The 90° wall sit is by definition at the limit — confirm with PT before progressing.
+- **Iliopsoas note:** Spine is upright against wall, hips in static flexion under closed-chain compression — iliopsoas not lengthening or contracting against gravity. Acceptable.
+
+#### 12. TRX-Assisted Step-Down (forward, low box)
+
+- **PWB level:** Right leg working; left leg controlled descent only
+- **Equipment:** TRX, 4 in box (low height, not standard 6–8 in)
+- **Setup:** Face anchor. Stand right leg on box, left leg hanging. Hands on straps.
+- **Execution:** Slow eccentric — left foot **lightly taps** floor, no weight transfer. 3-sec down, pause, 2-sec up. Right (stance) leg does the work; TRX offloads arms.
+- **Sets × reps:** 3 × 8 (right leg working)
+- **Rationale:** Single-leg strength on right side without compromising left. The light tap re-introduces left foot floor contact in a controlled, non-loaded way ([P]Rehab step-down](https://theprehabguys.com/step-ups/)).
+- **Safety / stop on:** Left foot bears weight on tap (should be feather-light). Right knee valgus.
+- **Hip flexion <90°:** YES (right side ~70°).
+- **Iliopsoas note:** Left leg is hanging passively — no flexion-against-gravity. Acceptable.
+
+---
+
+### CATEGORY 4 — Gait-quality drills (3)
+
+#### 13. Heel-to-Toe Tandem Walk
+
+- **PWB level:** FWB once cleared by PT (typically end of Phase 4)
+- **Equipment:** Tape line on floor; mat or wall nearby for catch-balance
+- **Setup:** Stand at start of tape line. Arms folded across chest (or one finger on wall for safety).
+- **Execution:** Walk heel directly in front of toe (tandem stance), 10 steps forward. Slow, deliberate.
+- **Sets × reps:** 3 × 10 steps
+- **Rationale:** Reintegrates proprioceptive heel-strike + frontal-plane stability. Listed in joint-replacement gait protocols ([HipKnee Info](https://hipkneeinfo.org/wp-content/uploads/2024/06/Gait-Training-Jan-2021.pdf)).
+- **Safety / stop on:** Major sway requiring catch — return to wall-supported version.
+- **Hip flexion <90°:** YES.
+- **Iliopsoas note:** Walking gait — iliopsoas demand minimal.
+
+#### 14. Marching in Place at PWB%
+
+- **PWB level:** 25–75% BW depending on tool
+- **Equipment:**
+  - Best: AlterG at 50% BW
+  - Alternative: Bathroom scale under each foot in mirror (visualize 50/50 load)
+- **Setup:** Stand upright, hands on hips or chest.
+- **Execution:** March, lifting each knee to **≤60° hip flexion** (NOT high knees — this would exceed the cap). Slow tempo, 60 step/min.
+- **Sets × reps:** 2 × 30 sec each leg, alternating
+- **Rationale:** Re-couples hip flexion + stance phase + ground reaction force. Classic gait drill ([Hip Fracture rehab](https://physiosc.com/media/rehabilitation-after-a-hip-fracture-the-role-of-physical-therapy)).
+- **Safety / stop on:** Any anterior hip pain on the *stance* phase (this is the tell for continued fracture).
+- **Hip flexion <90°:** YES — strict 60° cap on left.
+- **Iliopsoas note:** This is the highest-risk exercise in this list for left iliopsoas. **PT must clear and observe first session.** The left leg flexes against gravity, but with bilateral support from the right stance leg and AlterG offload, the load is reduced. Skip if any left iliopsoas pain history.
+
+#### 15. Single-Leg Stance Progression
+
+- **PWB level:** Variable per stage
+- **Equipment:** Floor → balance pad (Airex or similar) → eyes closed
+- **Setup:** Near a wall for safety. Stance leg under hip.
+- **Execution:** Stages (progress one per session if pain-free):
+  - Stage A: Right leg only on floor, 30 sec × 3
+  - Stage B: Right leg on foam pad, 30 sec × 3
+  - Stage C: Left leg on floor, 20 sec × 3 (ONLY after AlterG 75% pain-free)
+  - Stage D: Left leg on foam pad, 20 sec × 3 (Phase 5 territory — likely not Phase 4)
+- **Sets × reps:** As above
+- **Rationale:** Restores proprioception + closed-chain stability that NWB destroyed ([Rehab Hero](https://www.rehabhero.ca/exercise/balance-pad-single-leg-stance), [Princeton UHS](https://uhs.princeton.edu/sites/g/files/toruqf5356/files/documents/Pelvic-Stabilization-Hip-Strengthening.pdf)).
+- **Safety / stop on:** Any left hip pain at left-stance stages. Major sway requiring catch.
+- **Hip flexion <90°:** YES (stance is ~0° flexion).
+- **Iliopsoas note:** Static stance — iliopsoas not loaded. Safe.
+
+---
+
+### CATEGORY 5 — Glute medius reactivation (3)
+
+Glute med atrophy after NWB is well-documented. EMG data ranks the **side
+plank with hip abduction (top leg)** at 89–103% MVIC, the highest in any
+literature ([PMC EMG study](https://pmc.ncbi.nlm.nih.gov/articles/PMC3201064/)).
+These exercises remain side-lying or partially loaded — safe across the entire
+PWB transition.
+
+#### 16. Banded Clamshells (Level 4 — long lever)
+
+- **PWB level:** NWB-compatible (side-lying)
+- **Equipment:** Mini-band above knees; mat
+- **Setup:** Side-lying, knees bent **<60°** (FAI-safe), heels stacked, hips stacked.
+- **Execution:** Open top knee against band; **bottom knee stays planted** (no hip rotation). 2-sec up, 1-sec hold, 2-sec down. ([NASM clamshell](https://blog.nasm.org/banded-clamshell-workout))
+- **Sets × reps:** 3 × 12 each side (do right side, then left)
+- **Rationale:** Glute med activation at 77% MVIC ([PMC EMG](https://pmc.ncbi.nlm.nih.gov/articles/PMC3201064/)). Already in current program — keeps it.
+- **Safety / stop on:** Hip pinch (knee flexion too deep).
+- **Hip flexion <90°:** YES (60° cap).
+- **Iliopsoas note:** Side-lying = no gravity demand on iliopsoas. Safe.
+
+#### 17. Side Plank with Top-Leg Hip Abduction (R side down)
+
+- **PWB level:** NWB-compatible
+- **Equipment:** Mat
+- **Setup:** Right elbow on mat under shoulder, knees stacked (modified) OR feet stacked (full). Hold side plank. Top leg = LEFT.
+- **Execution:** From side plank, abduct top (left) leg ~30°, hold 5 sec, lower with control. **R side down** — this is the existing program's variant.
+- **Sets × reps:** 3 × 8 reps with 5-sec holds
+- **Rationale:** Highest-MVIC glute med exercise (89–103%, [PMC EMG](https://pmc.ncbi.nlm.nih.gov/articles/PMC3201064/)). Already in current Push A workout — extend to Phase 4.
+- **Safety / stop on:** Any anterior hip pain (left). Wrist/shoulder issues — drop to forearm modification.
+- **Hip flexion <90°:** YES (knees ≤60° if modified, 0° if full).
+- **Iliopsoas note:** Hip abduction in side-lying is gravity-perpendicular, not flexion-against-gravity. Safe.
+
+#### 18. Lateral Band Walk (semi-squat, ~30° knee/hip)
+
+- **PWB level:** Bilateral partial — use as later-Phase-4 progression only
+- **Equipment:** Mini-band at ankles (not knees — ankle position generates higher glute med MVIC, [PMC narrative review](https://pmc.ncbi.nlm.nih.gov/articles/PMC12372021/))
+- **Setup:** Mini-band around both ankles. Stand in 30° hip + 30° knee flexion (semi-squat).
+- **Execution:** Step laterally with control — slow, 1 step every 2 sec. Maintain semi-squat throughout. 10 steps right, 10 steps left.
+- **Sets × reps:** 3 × 10 steps each direction
+- **Rationale:** Reintroduces frontal-plane bilateral loading + glute med activation. Optimal at 30° knee/hip ([PMC review](https://pmc.ncbi.nlm.nih.gov/articles/PMC12372021/)).
+- **Safety / stop on:** Trendelenburg drop on left (pelvis drops on right). Any anterior hip pain.
+- **Hip flexion <90°:** YES (30°).
+- **Iliopsoas note:** Closed-chain bilateral stance with frontal-plane motion only. Iliopsoas demand low. Acceptable for **late Phase 4** (after AlterG 75% pain-free).
+
+---
+
+### CATEGORY 6 — Eccentric hamstring loading (2)
+
+**Bilateral proximal hamstring tendinosis is in play.** Per JOSPT,
+**minimize loaded hip flexion early to protect the enthesis from compression**
+([JOSPT](https://www.jospt.org/doi/10.2519/jospt.2016.5986)). Heavy slow
+resistance is the goal, but tempo > load in Phase 4.
+
+#### 19. Single-Leg Bridge — Right Leg, Knee-Extended Progression
+
+- **PWB level:** Right limb only (left rests passively or extended)
+- **Equipment:** Mat, optional 5–10 lb plate over pelvis
+- **Setup:** Supine, right knee bent ~80–90°, foot flat. Left leg fully extended on floor (not lifted). Arms relaxed by sides.
+- **Execution:** Drive through right heel; lift hips to neutral (don't hyperextend lumbar). 2-sec up, 3-sec hold, 3-sec down. **Progression:** start with right knee at 80°, gradually extend toward 120° (more hamstring biased) over weeks 7–8 ([JOSPT](https://www.jospt.org/doi/10.2519/jospt.2016.5986)).
+- **Sets × reps:** 3 × 8 right leg
+- **Rationale:** Moderate-to-high glute/ham/glute-med MVIC; bias toward hamstring as knee extends; tendon-friendly slow tempo.
+- **Safety / stop on:** Posterior hip / sit-bone pain (proximal ham flare). Lumbar pain — reduce hip extension ROM.
+- **Hip flexion <90°:** YES (lying down — gravity is perpendicular).
+- **Iliopsoas note:** Left leg passive on floor, no demand. Right leg working. Safe.
+
+#### 20. Reverse Treadmill Walking
+
+- **PWB level:** Start 0% incline; progress to 1–3% incline by week 8
+- **Equipment:** Treadmill (or AlterG with reverse mode at 75% BW)
+- **Setup:** Stand on stationary belt facing backward (away from console). Hold rails with light grip.
+- **Execution:** Belt moves forward → user walks backward. 1.5 mph start, 2.0 mph by week 8. Toe-then-heel contact.
+- **Sets × reps:** 2 × 3 min @ 1.5–2.0 mph
+- **Rationale:** Well-established eccentric hamstring loading without flexion compression at the enthesis ([RunningPhysio](https://www.running-physio.com/pht-rehab/)).
+- **Safety / stop on:** Posterior hip pain (sit-bone area). Gait imbalance.
+- **Hip flexion <90°:** YES (walking gait).
+- **Iliopsoas note:** Walking gait, minimal demand. Safe.
+
+---
+
+### CATEGORY 7 — Hip flexor retraining without iliopsoas overload (3)
+
+**The hardest category.** The whole point of Phase 4 is the user can return
+to gym/life movement, which inevitably requires *some* hip flexion against
+gravity on the left. The strategy: **gradually reload the iliopsoas in ranges
+where the line of pull does NOT compress the femoral neck**, and **use bent-
+knee (short-lever) variants** which reduce iliopsoas activation vs. straight-
+leg ([MDPI hip flexor EMG study](https://www.mdpi.com/2077-0383/13/21/6617)).
+
+#### 21. Supine Bent-Knee Heel Slides — Right Leg Only (Phase 4) → Cautious Left (Phase 5)
+
+- **PWB level:** Floor (no gravity-against-flexion component on left in this variant)
+- **Equipment:** Mat, towel under heel for low-friction slide
+- **Setup:** Supine, both knees bent, feet flat. Towel under right heel.
+- **Execution:** Slide right heel away from glute (extend knee), then slide back. **Knee stays in contact with floor — no lift.** This means hip stays at ~30° flexion max throughout — *NO active SLR motion.* 2-sec out, 2-sec in.
+- **Sets × reps:** 3 × 10 right leg
+- **Rationale:** Re-pattern the hip flexion mechanic on the safe side first, with strict knee-on-floor cue eliminating the flexion-against-gravity component. From [MDPI study](https://www.mdpi.com/2077-0383/13/21/6617): bent-knee supine work = lower iliopsoas activation than straight-leg.
+- **Safety / stop on:** Heel lifts off floor (becomes an active SLR — STOP).
+- **Hip flexion <90°:** YES (~30° max).
+- **Iliopsoas note:** Right side only in Phase 4. **Do NOT do this on the left in Phase 4** — even with knee on the floor, the pattern is too close to active SLR. Wait for Phase 5 + MRI clearance.
+
+#### 22. Standing Banded Hip Flexion <60° (right leg)
+
+- **PWB level:** Bilateral stance, supported
+- **Equipment:** Cable column with low-anchor ankle strap, OR resistance band + low anchor
+- **Setup:** Anchor band/cable LOW (ankle level). Attach to *right* ankle. Stand facing anchor, far enough back to remove slack. Hold rail or wall for stability.
+- **Execution:** Drive right knee up to **60° hip flexion max**, control return. 2-sec up, 3-sec down.
+- **Sets × reps:** 3 × 12 right leg
+- **Rationale:** Reintroduces standing hip flexion mechanic on the safe (right) side. Gives proprioceptive contrast that helps prevent over-guarding the left.
+- **Safety / stop on:** Loss of left-stance stability (Trendelenburg). Any left hip pain.
+- **Hip flexion <90°:** YES (60° cap).
+- **Iliopsoas note:** Right side only — left is in stance, not flexing. Safe.
+
+#### 23. Quadruped Hip Flexion Iso (right leg, hand-supported torso)
+
+- **PWB level:** Quadruped (hands and knees) — partial axial load
+- **Equipment:** Mat, low bench/bed for forearms (optional)
+- **Setup:** All-fours quadruped with **forearms on a low bench** (not floor-flat — bench raises torso to reduce hip flexion). Alternatively forearms-down on floor with neutral spine.
+- **Execution:** Extend right leg behind to neutral (hip in line with spine, NOT lifted into hip extension — this is the modified Bird-Dog variant). Hold isometric 8 sec. Slow controlled return.
+- **Sets × reps:** 3 × 8-sec holds, right leg only.
+- **Rationale:** Replaces the contraindicated Bird-Dog. Forearms-on-bench keeps the hip in a neutral, not-flexed position — eliminates the FAI risk. **Right-only** for Phase 4 because the left iliopsoas is the issue, not the right.
+- **Safety / stop on:** Lumbar pain (over-extension). Hip pinch.
+- **Hip flexion <90°:** YES (~30° in modified quadruped).
+- **Iliopsoas note:** Right working leg only. Left knee in stance position on mat — passive, supported, no flexion-against-gravity. Safe.
+
+---
+
+### CATEGORY 8 — Cycling (2)
+
+Cycling is the safest reintroduction of bilateral cyclical hip work. **Recumbent
+first** — open hip angle reduces iliopsoas tension; supported posture; near-zero
+balance demand ([PT and Me](https://ptandme.com/blog/recumbent-bikes-help-with-physical-therapy/)).
+Upright bike comes later, with high saddle height to keep hip flexion below 80°.
+
+#### 24. Recumbent Bike — Resistance Progression
+
+- **PWB level:** 0% standing BW (seated)
+- **Equipment:** Recumbent stationary bike (most gyms have one; home option: NordicTrack R35 or similar)
+- **Setup:** Seat back angle 10–15° reclined. Seat distance: **knee never exceeds 80° hip flexion at top of pedal stroke** — this likely means the seat is set further back than for cardio "fit." Test both feet at top of stroke before pedaling.
+- **Execution:** Steady cadence 70–85 RPM. Resistance starts at minimum (1–2 of 20). Progress 1 level per session if pain-free.
+- **Sets × reps:** Week 7: 15 min @ RPE 5; Week 8: 25 min @ RPE 5–6
+- **Rationale:** Reintroduces cyclical hip flexion in a supported, hip-flexion-controlled environment. Standard in femoral stress fracture protocols ([Coyner](https://www.drcoyner.com/pdf/femoral-stress-fracture-protocol-pt-version.pdf), [Hydroworx](https://www.hydroworx.com/blog/broken-femur-rehabilitation/)).
+- **Safety / stop on:** Anterior hip click; pinch at top of stroke (= seat too close, hip flexion >80°).
+- **Hip flexion <90°:** YES (explicit 80° cap).
+- **Iliopsoas note:** Seat back support reduces iliopsoas demand vs. upright. Cyclical loading is concentric+eccentric, *not* against gravity. Acceptable bilaterally.
+
+#### 25. Upright Stationary Bike — High-Saddle Spin
+
+- **PWB level:** Bilateral, low compression
+- **Equipment:** Upright stationary bike (or Peloton/spin bike)
+- **Setup:** Seat at full standing leg extension test — heel on pedal at 6 o'clock, leg should be **fully straight** (not the standard "30° bend" cyclist fit). This raises the saddle and **caps hip flexion at top of stroke around 75–80°**. No hands off bars.
+- **Execution:** Steady cadence 80–90 RPM. Light resistance (gear 2–3 of 8). Forward lean ≤15° (less than racing position).
+- **Sets × reps:** Week 7: 10 min @ RPE 4; Week 8: 15 min @ RPE 5
+- **Rationale:** Reintroduces upright bike position before any return to outdoor cycling. High saddle is the workaround for FAI + femoral neck. Supported by recumbent → upright progression in [Hydroworx](https://www.hydroworx.com/blog/broken-femur-rehabilitation/) and rehab cycling literature.
+- **Safety / stop on:** Forward lean past 15° (drops the hip into more flexion). Anterior hip pinch at top of stroke = saddle too low.
+- **Hip flexion <90°:** YES (75–80° cap by saddle height).
+- **Iliopsoas note:** Bilateral cyclical. Saddle height is the lever that controls iliopsoas load — high saddle = low load. Acceptable in **late Phase 4** only (after recumbent is comfortable).
+
+---
+
+## Programming notes for PT review
+
+### Suggested weekly structure (Phase 4 / Week 7)
+
+| Day | Focus | Exercises |
+|---|---|---|
+| Mon | Pool day | 1, 2, 3, 4, 5 (full aquatic block) |
+| Tue | Land day | 8, 11 (60°), 16, 17, 19 |
+| Wed | Recumbent + glute med | 24, 16, 17, 18 (deferred if late progressing) |
+| Thu | Pool day | 1, 2, 3, 4 |
+| Fri | AlterG day | 6, 7, 14, 15 (Stage A/B) |
+| Sat | Land day | 8, 9, 10, 11 (60°), 21 |
+| Sun | Recovery | 24 (light), 16, 19 |
+
+### Suggested weekly structure (Week 8)
+
+Increase wall sit to 75°, AlterG BW% to 65–75%, add #18 lateral band walk
+and #25 upright bike if Week 7 was uneventful. Begin testing #15 Stage C
+(left single-leg stance) in week 8 day 4–6.
+
+### Hard prerequisites before starting Phase 4
+
+1. New MRI showing **healing/healed** compression-side femoral neck stress fracture
+2. PT clearance to begin PWB
+3. Pain-free at rest for 2+ weeks
+4. Pain-free at end-range hip flexion (passive, supine, both sides) up to 80°
+5. Symmetric quad and glute med isometric strength (manual muscle testing) on PT exam
+
+### Open questions / items needing PT validation
+
+| Item | Why uncertain |
+|---|---|
+| #14 Marching in Place (left iliopsoas concern) | **Highest risk** in this list. PT must clear *and observe first session.* Could be substituted with marching only on right + isometric quad on left. |
+| #21 Supine Heel Slide on left side (Phase 4 vs Phase 5) | I've called it Phase 5; PT may judge it safe on left in late Phase 4. |
+| #22 Banded standing hip flexion (apply to left in Phase 4?) | I've kept it right-only. Ask PT whether band-resisted left flexion <30° standing could be safe with stance-leg support. |
+| AlterG availability + BW% schedule | Depends on local clinic equipment. If unavailable, the chest-deep aqua walk is the substitute. |
+| Wall sit at 90° | Patellofemoral force is highest at 90°; PT should confirm bilateral knees tolerate this before week 8. |
+| Single-leg stance on left + foam pad (Stage D) | I've called this Phase 5. Could be late Phase 4 if pain-free at Stage C. |
+| Reverse treadmill walking on AlterG | Whether the AlterG model supports reverse mode. |
+| #18 Lateral band walk timing | Bilateral partial-squat work — should be late Phase 4. PT may want it deferred entirely. |
+
+---
+
+## Sources (evidence base)
+
+- [Femoral Stress Fracture Protocol (Coyner) — PDF](https://www.drcoyner.com/pdf/femoral-stress-fracture-protocol-pt-version.pdf)
+- [Femoral Stress Fracture — Physiopedia](https://www.physio-pedia.com/Femoral_Stress_Fracture)
+- [Femoral Neck Hip Fracture — Physiopedia](https://www.physio-pedia.com/Femoral_Neck_Hip_Fracture)
+- [Treatment & Rehabilitation Approaches for Stress Fractures in Long-Distance Runners (PMC)](https://pmc.ncbi.nlm.nih.gov/articles/PMC10749698/)
+- [Management of femoral neck stress fractures in recreational runners (PMC)](https://pmc.ncbi.nlm.nih.gov/articles/PMC6357658/)
+- [Aquatic Therapy Post Lower-Limb Fracture (Water Resist)](https://waterresist.com.au/blogs/news/rehabilitation-post-fracture)
+- [Hydroworx — Broken Femur Aquatic Rehab](https://www.hydroworx.com/blog/broken-femur-rehabilitation/)
+- [Aquatic Therapy Exercises (Ivy Rehab)](https://ivyrehab.com/health-resources/physical-therapy/aquatic-therapy-exercises/)
+- [Sport Med Aquatic Therapy](https://sportmed.com/aquatics/)
+- [AlterG Anti-Gravity Treadmill (RX Physical Therapy)](https://rxphysicaltherapy.com/physical-therapy-treatments/alterg-anti-gravity-treadmill/)
+- [AlterG and Stress Fractures (Running Mate)](https://runningmatekc.com/2020-4-17-antigravity-treadmills-and-stress-fractures-do-they-help/)
+- [Anti-gravity treadmill RCT — partial weight-bearing post-lower-limb fracture (PMC)](https://pmc.ncbi.nlm.nih.gov/articles/PMC5348747/)
+- [TRX Rehab Exercises (Barbell Physio)](https://thebarbellphysio.com/best-trx-rehab-exercises/)
+- [TRX Hip Program — Dynamic Sports PT](https://www.dynamicsportspt.com/files/2012/04/TRX_Hip_Program.pdf)
+- [Optimizing Hip Abductor Strengthening — Monster Walk & Lateral Band Walk (PMC review)](https://pmc.ncbi.nlm.nih.gov/articles/PMC12372021/)
+- [EMG Analysis of Glute Med & Max During Rehab Exercises (PMC)](https://pmc.ncbi.nlm.nih.gov/articles/PMC3201064/)
+- [Banded Clamshell Workout (NASM)](https://blog.nasm.org/banded-clamshell-workout)
+- [Pelvic Stabilization, Lateral Hip and Gluteal Strengthening (Princeton UHS PDF)](https://uhs.princeton.edu/sites/g/files/toruqf5356/files/documents/Pelvic-Stabilization-Hip-Strengthening.pdf)
+- [Proximal Hamstring Tendinopathy — JOSPT clinical aspects](https://www.jospt.org/doi/10.2519/jospt.2016.5986)
+- [Proximal Hamstring Tendinopathy Rehab — RunningPhysio](https://www.running-physio.com/pht-rehab/)
+- [Proximal Hamstring Tendinopathy Rehab — E3 Rehab](https://e3rehab.com/proximal-hamstring-tendinopathy-rehab/)
+- [Hip Flexor Activation During Common Rehab Exercises (MDPI)](https://www.mdpi.com/2077-0383/13/21/6617)
+- [Patellofemoral force during wall squat (PubMed)](https://pubmed.ncbi.nlm.nih.gov/19276845/)
+- [P]Rehab — Step-Up & Step-Down Variations](https://theprehabguys.com/step-ups/)
+- [Balance Pad Single Leg Stance (Rehab Hero)](https://www.rehabhero.ca/exercise/balance-pad-single-leg-stance)
+- [Gait Training After Joint Replacement (HipKnee Info PDF)](https://hipkneeinfo.org/wp-content/uploads/2024/06/Gait-Training-Jan-2021.pdf)
+- [Recumbent Bike for PT (PT and Me)](https://ptandme.com/blog/recumbent-bikes-help-with-physical-therapy/)
+- [Femoral Neck Stress Fractures (Orthobullets)](https://www.orthobullets.com/knee-and-sports/3110/femoral-neck-stress-fractures)
+- [Differential Diagnosis of a Femoral Neck/Head Stress Fracture (JOSPT PDF)](https://www.jospt.org/doi/pdf/10.2519/jospt.2006.36.2.80)
+
+---
+
+## Document metadata
+
+- **Author:** Generated for PT review (Claude assistant)
+- **Date:** 2026-04-25
+- **Status:** Draft — DO NOT add to `lib/exercises.ts` until PT signs off
+- **Next step:** PT review meeting → mark approved/modified/rejected per row → second pass converts approved exercises into `Exercise` typed objects in `lib/exercises.ts` with diagrams.


### PR DESCRIPTION
Research deliverable for the upcoming weeks-7-8 PWB Prep phase. 25 exercises across 8 categories (aquatic, AlterG, TRX-assisted squats/lunges, gait drills, glute med, eccentric hamstring, hip flexor retraining, cycling). Each entry: PWB level, equipment, setup, execution, sets×reps, citation, stop signals, hip-flexion &lt;90° confirmation, iliopsoas load note. 28 cited sources. **For PT review before encoding into lib/exercises.ts.** Companion to docs/pwb-phase-research (clinical protocols).