### PR TITLE
docs(pwb): clinical-protocol research for Phase 4 PWB transition

### DIFF
--- a/docs/pwb-phase-research.md
+++ b/docs/pwb-phase-research.md
@@ -1,197 +1,149 @@
-# Partial Weight-Bearing (PWB) Rehabilitation Research
+# Phase 4 (Weeks 7–8): PWB Progression Clinical Protocol Research
 
-**Context:** Phase 4 of the 8-week NWB→PPL training program. The user is graduating from 8 weeks of strict NWB recovery from a left **compression-sided (inferomedial) femoral neck stress fracture (FNSF)**, with comorbid bilateral cam-type **FAI + labral tears** and **bilateral hamstring tendinosis**. Weeks 7–8 are "PWB Prep."
+**Scope:** Literature synthesis for the transition from 8-week strict NWB to partial weight bearing (PWB) after a left compression-sided (inferomedial) femoral neck stress fracture (FNSF). Comorbidities: bilateral cam-type FAI + labral tears, bilateral proximal hamstring tendinosis, mild R hip labral tear, L4-L5 DDD. Working with PT.
 
-**Scope note:** Literature synthesis, not medical advice. Numbers below are typical protocol benchmarks; advancement decisions belong with the supervising PT/orthopedist using the user's actual imaging and pain pattern.
+**This document is a clinical reference — not medical advice. All progression decisions require PT/MD sign-off on imaging and current symptom pattern.**
 
 ---
 
-## 1. Standard PWB Progression Timeline (Compression-Side FNSF)
+## 1. PWB Progression Timeline
 
-Compression-side (inferomedial) FNSFs are classified as **low-risk** under the Boden & Osbahr / Fullerton-Snowdy frameworks and are amenable to conservative management with strict offloading followed by graded reloading (Boden & Osbahr 2000; Robertson & Wood 2017; Stručić et al. 2018). Tension-side (superolateral) lesions are high-risk and typically receive surgical fixation; this document is calibrated to the compression-sided pattern.
+Compression-sided (inferomedial) FNSFs are classified as **low-risk** under the Boden-Osbahr and Fullerton-Snowdy frameworks and are suitable for conservative management with graded reloading once strict offloading has consolidated the healing response (Boden & Osbahr, *JAAOS* 2000; Robertson & Wood, *Sports Med Open* 2017).
 
-### Typical conservatively-managed timeline
-
-| Stage | Load | Typical duration | Cumulative wk post-injury |
+| Stage | Load | Typical duration | Cumulative weeks post-injury |
 |---|---|---|---|
-| 0. Strict NWB | 0% BW (crutches) | 4–6 wk (some up to 8) | 0–6 |
-| 1. Toe-Touch / TTWB | ~10–25% BW | 1–2 wk | 6–8 |
-| 2. PWB ~50% BW | half BW on crutches | 1–2 wk | 8–10 |
-| 3. PWB ~75% BW | one crutch (opposite side) | 1–2 wk | 9–11 |
-| 4. WBAT → FWB | no aids | 1–3 wk | 10–14 |
-| 5. Loading drills | stairs, marching, step-ups | starts ~wk 6 of reload | from ~12 |
-| 6. Return-to-run | graded run-walk → continuous | 6–8 wk progression | starts ~12; full RTR 18–24 |
+| Strict NWB | 0% BW | 4–8 wk (this program: 6 full weeks) | 0–6 |
+| Toe-touch (TTWB) | ~10–25% BW | 1–2 wk | 6–8 |
+| PWB ~50% BW | bilateral crutches, half BW | 1–2 wk | 8–10 |
+| PWB ~75% BW | single crutch (contralateral) | 1–2 wk | 9–11 |
+| WBAT → FWB | no aids | 1–3 wk | 10–14 |
+| Loading drills | stairs, marching, step-ups | starts ~wk 6 of reload | from ~12 |
+| Return to run | graded run-walk protocol | 6–8 wk progression | starts ~12; RTR ~18–24 |
 
-A 2023 systematic review (Robertson et al., *J Clin Orthop Trauma*, PMC10400407) reported conservatively-treated FNSF achieved **full weight-bearing at 7.5 ± 2.4 wk**, **loading activities (stairs/marching) at 6.1 ± 0.5 wk**, and **return to pre-injury activity at 7.7 ± 1.0 wk** — faster than surgical cases. Earlier reviews quote 6–14 wk total to FWB and **return to running typically ~12 wk post-injury** (Robertson & Wood 2017). Long-term: 71% return to full pre-injury activity, 24% functional with residual pain, 4% disabling pain.
+A 2023 systematic review (Yang et al., *J Orthop Trauma*; PMC10400407) found conservatively managed FNSFs achieved **full weight-bearing at 7.5 ± 2.4 wk** and **full pre-injury activity at 7.7 ± 1.0 wk** — faster than surgical cohorts. Long-term: 71% returned to full activity, 24% functional with residual pain, 4% disabling pain.
 
-### Clinical signs that trigger advancement
-1. **Pain-free at current load** ≥3–5 consecutive days, including 24 h post-session.
-2. **No pain with single-leg stance** (hop test deferred to FWB).
-3. **No groin/anterior-thigh pain at rest or at night.**
-4. **Symmetric, non-antalgic gait** (no Trendelenburg).
-5. **No tenderness** to deep palpation of the inferior femoral neck / adductor tubercle.
-6. **No reproduction** of pain with FABER (Patrick) or log-roll.
+**Advancement criteria (each stage requires all of the following):**
+- Pain-free at current load for ≥3–5 consecutive days, including 24 h post-session
+- No groin pain at rest or overnight
+- Symmetric, non-antalgic gait (no Trendelenburg) within the same session
+- No tenderness to palpation over the inferior femoral neck / adductor tubercle
+- No reproduction of pain with log-roll or FABER (Patrick) test
 
-Sources: Kaeding 2005; Warden et al. *JOSPT* 2014; Boden & Osbahr 2000.
+Apply the **10% rule**: advance only one parameter per week — load percentage, duration, or exercise complexity; never all three simultaneously (Warden, Davis, Fredericson, *JOSPT* 2014).
 
 ---
 
-## 2. Imaging & Clinical Clearance Before Advancing
+## 2. Imaging and Clinical Clearance Before Advancing PWB
 
-Imaging follow-up for compression-side FNSF is **not standardized** — most protocols describe clinically-driven progression with imaging used selectively.
+No universal imaging protocol exists for compression-side FNSF; most published protocols are clinically driven with selective imaging (Robertson & Wood 2017; Stručić et al., *J Orthop Surg Res* 2018).
 
-| When | Modality | Purpose |
+| Decision point | Recommended modality | Rationale |
 |---|---|---|
-| Before reloading (~wk 6–8) | **Repeat MRI** (preferred) or CT | Confirm reduced marrow edema; rule out fracture-line progression. MRI grade independently predicts recovery time (Nattiv et al. *AJSM* 2013) |
-| If pain returns at a new stage | MRI | Differentiate remodeling pain from fracture progression vs. labral/synovitis pain |
-| Before RTR | MRI optional in athletes | Confirm cortical/trabecular healing |
+| Before any reload (~wk 6–8) | **Repeat MRI** (preferred) or CT | Confirm reduced marrow edema; exclude fracture-line progression. MRI grade is an independent predictor of return-to-sport timing (Nattiv et al., *AJSM* 2013) |
+| Pain resurgence at any new stage | Urgent MRI | Distinguish remodeling pain from fracture progression vs. labral or synovitic flare |
+| Before return to running | MRI optional in recreational athletes | Confirm cortical-trabecular continuity |
 
-Plain radiographs are **insensitive** in the first 4–6 weeks and should not be used to clear progression (Gurney et al. *JOSPT* 2006). Higher MRI grade and lower BMD independently predict longer recovery (Nattiv 2013).
+Plain radiographs are **insensitive** in the first 4–6 weeks post-injury and should not be used as a clearance tool alone (Gurney et al., *JOSPT* 2006). The presence of hip joint effusion on initial or follow-up MRI predicts higher-grade injury and warrants conservative extension of the NWB period.
 
-**Pain-provocation tests at every PT visit:** log-roll, FABER, hip resisted SLR (positive when iliopsoas-loaded — relevant to user's left iliopsoas constraint), single-leg hop (deferred to late stage), femoral-neck palpation.
+Higher MRI grade and lower bone mineral density (BMD) independently predict longer recovery; **a DEXA scan and metabolic panel (vitamin D, ferritin, hormones) should be obtained if not already done** (Nattiv et al. 2013; Yang et al. 2023).
+
+**Routine pain-provocation tests at each PT visit:** log-roll, FABER, femoral-neck palpation, hip resisted SLR (also screens for iliopsoas activation — relevant per constraint #1 in §5). Single-leg hop test is deferred until FWB is pain-free.
 
 ---
 
-## 3. Recommended Exercises by PWB Phase
+## 3. Aquatic Therapy and Alter-G as Gold-Standard Early PWB Tools
 
-Filtered through the user's three additional constraints (FAI <90° hip flex, no left iliopsoas activation against gravity, hamstring-tendinosis-tolerant loading).
+### Aquatic therapy (pool)
+Water buoyancy modulates effective body weight by depth: **chest-deep ≈ 25–35% BW; waist-deep ≈ 40–50% BW; mid-thigh ≈ 60–75% BW** (Brennan, *Clin Sports Med* 1996). This allows graded axial loading of the femoral neck while eliminating foot-strike impact — ideal for TTWB and 25% stages.
 
-### 3a. Aquatic / pool-based (gold standard early PWB tool)
-Water depth modulates effective BW: chest-deep ≈25–35%, waist-deep ≈40–50%, mid-thigh ≈60–75% (Brennan, *Clin Sports Med* 1996). Buoyancy unloads the femoral neck while permitting full ROM and proprioceptive feedback.
+**Protocol (weeks 7–8):**
+- Deep-water running with flotation belt: 15–20 min, 2–3×/wk. Maintain upright trunk; cadence constrained to keep hip flex ≤ 90° (cam-FAI accommodation).
+- Chest-deep forward/backward/lateral walking: recruits glute med without compressive femoral neck loading.
+- Seated pool hip abduction with noodle resistance — **omit open-chain left hip flexion against noodle** (iliopsoas constraint).
+- Pool squats to a block at ≈ 80° knee flex; hip flex stays comfortably < 90°.
 
-- **Deep-water running** with a flotation belt (TTWB equivalent): start wk 6–7. Upright trunk; cadence kept **≤90° hip flex** to respect cam.
-- **Chest-deep walking**: forward, backward, sidestep — recruits glute med without overloading the femoral neck.
-- **Pool squats** to a stop block at ~80° knee flexion (preserves <90° hip flex).
-- **Pool hip abduction / extension** with noodle resistance; **avoid** open-chain hip flexion against the noodle on the **left** (iliopsoas constraint).
-- **Prone flutter kick** on a board — gentle hamstring loading without compressive deep flex.
+Swimming laps remain contraindicated (bilateral FAI, and flutter kick loads the left iliopsoas).
 
-### 3b. Anti-gravity treadmill (AlterG) if accessible
-Differential air pressure provides 20–100% BW unloading in 1% increments. Programming:
-- Begin ~wk 7 at **50% BW walking, 0° incline, 1.5–2.5 mph**, 10–15 min.
-- Progress **+10% BW every 5–7 sessions** if pain-free and gait symmetric.
-- Add intervals at **75% BW** before progressing to land jogging.
+### Alter-G anti-gravity treadmill
+Differential air pressure (DAP) technology enables 20–100% BW in 1% increments, preserving natural gait mechanics better than pool walking. RCT evidence (Henkelmann et al., *Clin Rehabil* 2020; Palke et al., *Clin Rehabil* 2021) in lower-limb fracture patients showed AlterG produced significantly **less thigh muscle atrophy at 6 weeks** and **superior gait quality at 1 year** vs. standard land PT.
 
-Henkelmann et al. *Clin Rehabil* 2020/2021 RCTs (in tibial plateau / ankle fractures) found AlterG produced **less thigh muscle atrophy** at 6 wk and **better gait quality at 1 yr** vs standard PT — relevant rationale for preserving quad/glute mass during PWB.
+**Protocol (if clinic has access):**
+- Begin wk 7 at **50% BW, flat grade, 1.5–2.5 mph, 10–15 min**.
+- Progress **+10% BW every 5–7 sessions** if gait is symmetric and pain-free.
+- Add intervals at 75% BW before progressing to land walking without assistive device.
 
-### 3c. Land-based PWB exercises
+---
 
-**Early (TTWB / 25%):**
-- **Counter-balanced TRX-assisted mini-squat** (vertical shins, ≤60° knee flex, hip flex ≤80°).
-- **Wall slides** to a block (knee flex limited so hip stays <90°).
-- **Heel-to-toe (tandem) walking** in front of a mirror — gait re-education.
-- **Marching in place** to ≤80° hip flex *seated/supported* on the right; **left side seated only** (iliopsoas constraint).
-- **Single-leg balance on the right**, progressing to left in the 50–75% BW phase.
+## 4. Land-Based PWB Exercise Principles
 
-**Mid (50% BW):**
-- **Step-up onto 4-inch box, leading with the left**, with 1–2 fingers of rail support. Box height 4 → 6 → 8 inches across the phase.
-- **Standing banded hip abduction** — strong glute med driver, low FNSF load.
-- **Bridges** (current); reduce dose if hamstring tendinosis flares.
-- **Side plank with bottom-knee bent** — frontal-plane control without compressive flex.
+### TRX-assisted and counterbalanced movement
+- **TRX mini-squat** with vertical shins and ≤ 60° knee flex: partial BW on left via suspension. Hip flex < 80°. Maintain neutral lumbar curve to protect L4-L5.
+- **Wall slides with block**: same hip/knee angle constraint; block prevents excess depth.
+- **Tandem heel-to-toe walking** in front of a mirror for early gait re-education.
 
-**Late (75% → FWB):**
-- **Bodyweight squats** to ~80° knee flex (preserve <90° hip flex).
-- **Forward and lateral step-downs** — eccentric control.
-- **Single-leg RDL, partial-range** (≤80° hip hinge): isometric → slow eccentric only after FWB pain-free.
-- **AVOID curtsy lunges** (combined flex + adduction + IR provokes cam impingement).
+### Proprioception and gait-quality work
+- Single-leg balance on the **right** first (TTWB phase); introduce left at 50% BW phase.
+- Visual biofeedback with mirror or phone camera to monitor Trendelenburg sign.
+- Gait cueing: "tall posture, equal step length, foot strike beneath COM."
 
-### 3d. Cycling
-- **Recumbent bike**: appropriate from **wk 6–8**. Low femoral-neck shear, no foot-strike load, hip flex easily kept <90° via seat-back angle. Start 10 min zero resistance → 20–30 min low resistance.
-- **Upright stationary bike**: introduce at **50% BW phase (~wk 8–10)**. Set saddle high (low knee/hip flex angles); avoid out-of-saddle pedaling until FWB.
-- **Standing/road cycling**: defer until cleared for FWB.
+### Glute med reactivation (highest priority)
+Gluteal activation during loading reduces acetabular contact pressure ~32% in cam-FAI, providing synergistic benefit for both the healing fracture site and the labrum (Lewis, Khuu, Loverro, PMID 36549048).
 
-Cycling does not load the femoral neck axially, but high-cadence pedaling at low saddle heights drives hip flex past 90° and provokes FAI — saddle setup matters more than the bike itself.
-
-### 3e. Hip mobility & strengthening (FAI- and iliopsoas-tolerant)
-
-**Glute med activation** (highest priority — gluteal activation reduces acetabular contact pressure ~32% in FAI per Lewis et al. PMID 36549048):
-- Side-lying clamshells (hip flex <60°)
+- Side-lying clamshells (hip flex < 60°)
 - Side-lying straight-leg hip abduction
-- Banded sidestepping (FWB phase only)
-- Pelvic-drop / single-leg-stance pelvic-level drill
+- Standing banded hip abduction (FWB phase)
+- Pelvic-drop / Trendelenburg corrective drill in front of mirror
 
-**Left hip flexor "retraining" without iliopsoas overload:**
-- *Right* side: standard supine leg raise / dead-bug.
-- *Left* side: **isometric only** in early PWB (e.g., supine, knee bent 30°, gentle press into a strap at the knee — recruits rectus femoris without lifting against gravity). Add against-gravity left hip flexion only after FWB and explicit MD/PT clearance.
-
-**Eccentric hamstring loading (mindful of tendinosis):** Goom et al. *JOSPT* 2016 3-stage progressive model:
-- **Phase 1 isometric**: 70% MVC, hip ≤70° flex, 5×30–45 s, pain ≤3/10, settling within 24 h. Prone iso leg-curl, neutral-hip bridge, iso long-leg bridge.
-- **Phase 2 heavy slow resistance** (15RM → 8RM) once isometrics pain-free: standing single-leg hip thrust, slow leg curl, partial-range deadlift.
-- **Phase 3 energy storage / plyo**: only after FWB and pain-free running. **Defer well past Phase 4 of this program.**
-
-User has already removed seated ham curl + deep RDLs — consistent with this literature. Avoid Nordic curls until end of Phase 3.
-
-**Cam-impingement avoidance (FADIR principle):** the provocative position is simultaneous flex + adduction + IR. Corollaries: no deep squat with valgus collapse, no pigeon stretch, no figure-4 past 80° hip flex, no loaded hip-flexion machines, build glute/external-rotator strength to passively limit IR during gait.
-
-### 3f. Sample weekly schedule (Phase 4, wk 7–8)
-
-Pool 2×/wk, bike daily, no AlterG. Insert into existing PPL framework.
-
-| Day | PPL | PWB add-on (15–25 min) |
-|---|---|---|
-| Mon (Push) | upper push | Pool deep-water run 15 min + R-side balance |
-| Tue (Pull) | upper pull | Recumbent bike 20 min + clamshells / sidesteps |
-| Wed (Legs) | NWB legs | AlterG or pool walking 15 min @ 50% BW; ham iso phase 1 |
-| Thu (rest) | mobility | Pool walking 20 min waist-deep; SL-stance R |
-| Fri (Push) | upper push | Recumbent bike 20 min + glute-med set |
-| Sat (Pull) | upper pull | Pool deep-water run 20 min + low step-ups |
-| Sun (Legs) | NWB legs | Land walk 5–10 min TTWB→25%; gait drills |
-
-**Progression rule:** advance one parameter per week (load %, time, *or* complexity) — never all three. The 10% rule (Warden 2014) applies.
+### Step work and eccentric loading (mid and late PWB)
+- Step-ups leading with the left onto a 4-inch box (1–2 fingers of rail support), advancing to 6-inch and 8-inch over the phase
+- Forward and lateral step-downs for eccentric quad control
+- Partial-range single-leg RDL (≤ 70° hip hinge) starting isometrically once at FWB and pain-free — respect hamstring tendinosis loading parameters (see §5)
 
 ---
 
-## 4. Constraints to Flag with the PT
+## 5. Constraints Flagged for the PT
 
-1. **NO against-gravity left iliopsoas activation.** The iliopsoas tendon crosses anterior to the femoral neck; concentric left hip flexion compresses the fracture site. Until consolidation on follow-up MRI, all left hip flexion must be supported (seated, supine assisted, or in water) or isometric.
-2. **Bilateral hip flex <90°** — limit squat/box height/saddle setup accordingly.
-3. **Bilateral hamstring tendinosis** — no high-tempo eccentrics, no Nordic curls, no deep RDLs until Phase 3 milestones met.
-4. **Cam impingement** — flag any FADIR-position exercise. Pigeon, deep figure-4, low-saddle cycling, loaded hip-flexor machines, curtsy lunges are out.
-5. **Left side always 1 phase behind right** when in doubt.
+The following constraints carry forward from Phases 1–3 and are **non-negotiable through Phase 4** pending explicit MD/PT clearance based on imaging and clinical exam.
 
----
+1. **NO against-gravity left iliopsoas activation.** The iliopsoas tendon passes anterior to the femoral neck; concentric left hip flexion in open chain compresses the healing fracture site. Left hip flexion must remain supported (seated, supine assisted, or aquatic) or purely isometric until follow-up MRI confirms consolidation and PT/MD explicitly advance this restriction.
 
-## 5. Red Flags / Stop-and-See-PT-or-MD
+2. **Hip flexion < 90° bilaterally (bilateral cam-FAI + labral tears).** This constrains squat depth, saddle height on the bike, step-box height, aquatic cadence, and seated exercise positioning. The provocative triad for cam impingement — simultaneous flexion + adduction + internal rotation (FADIR) — must be screened out of every new exercise. Avoid deep pigeon, figure-4 past 80°, curtsy lunges, and loaded hip-flexor machines.
 
-Halt progression and obtain clinical evaluation (low threshold for repeat MRI) if:
-- **Groin pain at rest or at night** — classic FNSF progression sign; mandates imaging and likely return to NWB.
-- **Anterior thigh pain** worsening with walking or stairs.
-- **Pain not resolving within 24 h** post-session, or escalating session-over-session.
-- **New limp or Trendelenburg** that doesn't resolve within the same session.
-- **Inability to perform pain-free SLR** — Boden's classic re-evaluation trigger.
-- **Increasing pain** with FABER or log-roll that was previously decreasing.
-- **Mechanical hip symptoms** (catching, locking, painful deep clicking) — labral, but worth a visit.
-- **Constitutional symptoms** (fevers, weight loss) — atypical, but femoral-neck marrow edema can have non-fracture causes (Kurt Oktay et al. 2025).
+3. **No violent hamstring eccentrics (bilateral proximal hamstring tendinosis).** Apply the Goom-Malliaras-Purdam three-stage framework (*JOSPT* 2016): Phase 1 isometric holds (70% MVC, hip ≤ 70° flex, 5 × 45 s, pain ≤ 3/10 settling within 24 h) → Phase 2 heavy-slow-resistance isotonics (only when Phase 1 pain-free) → Phase 3 energy storage / plyometric loading (defer well past this program). Nordic curls, seated hamstring curls, and deep RDLs remain off the table for Phase 4.
 
-The single most reliable early-warning sign: **resumption of pain at rest or at night**. This almost always precedes radiographic progression.
+4. **L4-L5 DDD:** Avoid sustained lumbar flexion under load. Squat, step, and hinge cues should emphasize neutral lumbar spine; TRX and wall-slide setups reduce spinal compression vs. freestanding barbell work. Core bracing before any land-based PWB movement.
+
+5. **Left side always one sub-phase behind right** when clinical uncertainty exists — err toward protecting the fracture site.
 
 ---
 
-## 6. References (cited above)
+## 6. Red Flags During PWB — Stop and Contact MD/PT
 
-According to PubMed and PMC retrievals:
+Halt all progression immediately and seek clinical evaluation (low threshold for urgent repeat MRI) if any of the following occur:
 
-1. **Boden BP, Osbahr DC.** High-risk stress fractures: evaluation and treatment. *J Am Acad Orthop Surg* 2000;8(6):344–353. [DOI](https://doi.org/10.5435/00124635-200011000-00002).
-2. **Robertson GAJ, Wood AM.** Femoral neck stress fractures in sport: a current concepts review. *Sports Med Open* 2017;3(1). PMC6226070.
-3. **Robertson GAJ et al.** Femoral neck stress fracture return to activity and the effect of metabolic dysfunction on recovery: a systematic review. *J Clin Orthop Trauma* 2023. PMC10400407.
-4. **Stručić I et al.** Management and treatment of femoral neck stress fractures in recreational runners. *J Orthop Surg Res* 2018. PMC6357658.
-5. **Kaeding CC et al.** Management and return to play of stress fractures. *Clin J Sport Med* 2005;15(6):442–447. [DOI](https://doi.org/10.1097/01.jsm.0000188207.62608.35). PMID 16278549.
-6. **Warden SJ, Davis IS, Fredericson M.** Management and prevention of bone stress injuries in long-distance runners. *J Orthop Sports Phys Ther* 2014;44(10):749–765. [DOI](https://doi.org/10.2519/jospt.2014.5334).
-7. **Nattiv A et al.** Correlation of MRI grading of bone stress injuries with clinical risk factors and return to play: a 5-year prospective study. *Am J Sports Med* 2013;41(8):1930–1941. [DOI](https://doi.org/10.1177/0363546513490645). PMID 23825184.
-8. **Gurney B, Boissonnault WG, Andrews R.** Differential diagnosis of a femoral neck/head stress fracture. *J Orthop Sports Phys Ther* 2006;36(2):80–88. [DOI](https://doi.org/10.2519/jospt.2006.36.2.80). PMID 16494075.
-9. **Henkelmann R et al.** Impact of anti-gravity treadmill rehabilitation therapy on outcomes after fixation of lower limb fractures: RCT. *Clin Rehabil* 2020;35(3):356–366. [DOI](https://doi.org/10.1177/0269215520966857). PMID 33106057.
-10. **Palke L et al.** Anti-gravity treadmill rehabilitation improves gait and muscle atrophy after ankle and tibial plateau fractures at 1 yr: RCT. *Clin Rehabil* 2021;36(1):87–98. [DOI](https://doi.org/10.1177/02692155211037148). PMID 34355605.
-11. **Goom TSH, Malliaras P, Reiman MP, Purdam CR.** Proximal hamstring tendinopathy: clinical aspects of assessment and management. *J Orthop Sports Phys Ther* 2016;46(6):483–493. [DOI](https://doi.org/10.2519/jospt.2016.5986).
-12. **Lewis CL, Khuu A, Loverro KL.** Gluteal activation during squatting reduces acetabular contact pressure in FAIS: patient-specific FE analysis. [PMID 36549048](https://pubmed.ncbi.nlm.nih.gov/36549048/).
-13. **Kurt Oktay KN, Uysal M, Geler Kulcu D.** Femoral neck bone marrow edema during isotretinoin therapy: case report. *Am J Phys Med Rehabil* 2025. [DOI](https://doi.org/10.1097/PHM.0000000000002911).
+- **Groin or anterior thigh pain at rest or at night** — the earliest and most reliable sign of fracture progression under load; mandates NWB and imaging before any further advancement
+- **Pain that does not resolve within 24 hours post-session**, or that escalates session over session
+- **New or worsening limp or Trendelenburg gait** that fails to resolve within the same session
+- **Increasing pain with FABER or log-roll** that was previously resolving
+- **Inability to perform a pain-free straight-leg raise** (Boden re-evaluation trigger)
+- **Mechanical hip symptoms** — catching, locking, or painful deep clicking (labral tear or loose body; relevant given bilateral labral pathology)
+- **Skin or neurovascular changes** in the left thigh or leg (rare; screens for AVN or synovitis)
+
+The single most reliable early warning sign in the literature: **resumption of pain at rest or overnight after it had resolved.** This almost universally precedes radiographic evidence of fracture progression and demands return to the previous load stage or to strict NWB pending imaging.
 
 ---
 
-## 7. Open Questions for the PT Visit
+## 7. References
 
-1. **Current MRI grade / marrow-edema status at wk 6 follow-up?** Higher grade → push timeline 1–2 wk right.
-2. **DEXA / vit D / RED-S workup done?** Robertson 2023 found abnormal bone metabolism predicts delayed recovery; uniformly under-investigated in published cohorts.
-3. **AlterG accessible at the user's PT clinic?** Substantially changes §3f schedule.
-4. **Follow-up MRI before reload?** Strongly recommended — cam-FAI complication makes pain interpretation harder than a pure FNSF.
-5. **Explicit MD/surgeon go-ahead for reload at wk 8?** PWB without that clearance is premature even if symptoms favor.
-
-The literature is clear: compression-side FNSF responds well to graded reload **when reload starts on time and progression is pain-guided**. The user's overlapping FAI / labral / hamstring picture means the *limiting tissue* during reload may not be the femoral neck itself — pain may come from labrum or proximal hamstring before bone — making ongoing PT supervision more important than usual.
+1. **Boden BP, Osbahr DC.** High-risk stress fractures: evaluation and treatment. *J Am Acad Orthop Surg.* 2000;8(6):344–353. DOI: 10.5435/00124635-200011000-00002
+2. **Robertson GAJ, Wood AM.** Femoral neck stress fractures in sport: a current concepts review. *Sports Med Open.* 2017;3(1):22. PMC6226070
+3. **Yang K, Sambandam S, Yan MJ, Huo M.** Femoral neck stress fracture return to activity and the effect of metabolic dysfunction on recovery: a systematic review. *J Clin Orthop Trauma.* 2023. PMC10400407
+4. **Stručić I, Starešinić M, Bojanić I, et al.** Management and treatment of femoral neck stress fractures in recreational runners. *J Orthop Surg Res.* 2018;13:54. PMC6357658
+5. **Nattiv A, Kennedy G, Barrack MT, et al.** Correlation of MRI grading of bone stress injuries with clinical risk factors and return to play: a 5-year prospective study in collegiate track and field athletes. *Am J Sports Med.* 2013;41(8):1930–1941. PMID 23825184
+6. **Gurney B, Boissonnault WG, Andrews R.** Differential diagnosis of a femoral neck/head stress fracture. *J Orthop Sports Phys Ther.* 2006;36(2):80–88. PMID 16494075
+7. **Warden SJ, Davis IS, Fredericson M.** Management and prevention of bone stress injuries in long-distance runners. *J Orthop Sports Phys Ther.* 2014;44(10):749–765. DOI: 10.2519/jospt.2014.5334
+8. **Goom TSH, Malliaras P, Reiman MP, Purdam CR.** Proximal hamstring tendinopathy: clinical aspects of assessment and management. *J Orthop Sports Phys Ther.* 2016;46(6):483–493. DOI: 10.2519/jospt.2016.5986
+9. **Henkelmann R, Frosch K-H, Glaab R, et al.** Impact of anti-gravity treadmill rehabilitation on outcomes after fixation of lower limb fractures: randomized controlled trial. *Clin Rehabil.* 2020;35(3):356–366. PMID 33106057
+10. **Palke L, Henkelmann R, Frosch K-H, et al.** Anti-gravity treadmill therapy improves gait and prevents muscle atrophy at 1 year: RCT. *Clin Rehabil.* 2021;36(1):87–98. PMID 34355605
+11. **Lewis CL, Khuu A, Loverro KL.** Gluteal activation during squatting reduces acetabular contact pressure in femoroacetabular impingement syndrome: patient-specific finite element analysis. PMID 36549048
+12. **Kaeding CC, Najarian RG.** Stress fractures: classification and management. *Phys Sportsmed.* 2010;38(3):45–54. DOI: 10.3810/psm.2010.10.1807

--- a/docs/pwb-phase-research.md
+++ b/docs/pwb-phase-research.md
@@ -1,0 +1,197 @@
+# Partial Weight-Bearing (PWB) Rehabilitation Research
+
+**Context:** Phase 4 of the 8-week NWB→PPL training program. The user is graduating from 8 weeks of strict NWB recovery from a left **compression-sided (inferomedial) femoral neck stress fracture (FNSF)**, with comorbid bilateral cam-type **FAI + labral tears** and **bilateral hamstring tendinosis**. Weeks 7–8 are "PWB Prep."
+
+**Scope note:** Literature synthesis, not medical advice. Numbers below are typical protocol benchmarks; advancement decisions belong with the supervising PT/orthopedist using the user's actual imaging and pain pattern.
+
+---
+
+## 1. Standard PWB Progression Timeline (Compression-Side FNSF)
+
+Compression-side (inferomedial) FNSFs are classified as **low-risk** under the Boden & Osbahr / Fullerton-Snowdy frameworks and are amenable to conservative management with strict offloading followed by graded reloading (Boden & Osbahr 2000; Robertson & Wood 2017; Stručić et al. 2018). Tension-side (superolateral) lesions are high-risk and typically receive surgical fixation; this document is calibrated to the compression-sided pattern.
+
+### Typical conservatively-managed timeline
+
+| Stage | Load | Typical duration | Cumulative wk post-injury |
+|---|---|---|---|
+| 0. Strict NWB | 0% BW (crutches) | 4–6 wk (some up to 8) | 0–6 |
+| 1. Toe-Touch / TTWB | ~10–25% BW | 1–2 wk | 6–8 |
+| 2. PWB ~50% BW | half BW on crutches | 1–2 wk | 8–10 |
+| 3. PWB ~75% BW | one crutch (opposite side) | 1–2 wk | 9–11 |
+| 4. WBAT → FWB | no aids | 1–3 wk | 10–14 |
+| 5. Loading drills | stairs, marching, step-ups | starts ~wk 6 of reload | from ~12 |
+| 6. Return-to-run | graded run-walk → continuous | 6–8 wk progression | starts ~12; full RTR 18–24 |
+
+A 2023 systematic review (Robertson et al., *J Clin Orthop Trauma*, PMC10400407) reported conservatively-treated FNSF achieved **full weight-bearing at 7.5 ± 2.4 wk**, **loading activities (stairs/marching) at 6.1 ± 0.5 wk**, and **return to pre-injury activity at 7.7 ± 1.0 wk** — faster than surgical cases. Earlier reviews quote 6–14 wk total to FWB and **return to running typically ~12 wk post-injury** (Robertson & Wood 2017). Long-term: 71% return to full pre-injury activity, 24% functional with residual pain, 4% disabling pain.
+
+### Clinical signs that trigger advancement
+1. **Pain-free at current load** ≥3–5 consecutive days, including 24 h post-session.
+2. **No pain with single-leg stance** (hop test deferred to FWB).
+3. **No groin/anterior-thigh pain at rest or at night.**
+4. **Symmetric, non-antalgic gait** (no Trendelenburg).
+5. **No tenderness** to deep palpation of the inferior femoral neck / adductor tubercle.
+6. **No reproduction** of pain with FABER (Patrick) or log-roll.
+
+Sources: Kaeding 2005; Warden et al. *JOSPT* 2014; Boden & Osbahr 2000.
+
+---
+
+## 2. Imaging & Clinical Clearance Before Advancing
+
+Imaging follow-up for compression-side FNSF is **not standardized** — most protocols describe clinically-driven progression with imaging used selectively.
+
+| When | Modality | Purpose |
+|---|---|---|
+| Before reloading (~wk 6–8) | **Repeat MRI** (preferred) or CT | Confirm reduced marrow edema; rule out fracture-line progression. MRI grade independently predicts recovery time (Nattiv et al. *AJSM* 2013) |
+| If pain returns at a new stage | MRI | Differentiate remodeling pain from fracture progression vs. labral/synovitis pain |
+| Before RTR | MRI optional in athletes | Confirm cortical/trabecular healing |
+
+Plain radiographs are **insensitive** in the first 4–6 weeks and should not be used to clear progression (Gurney et al. *JOSPT* 2006). Higher MRI grade and lower BMD independently predict longer recovery (Nattiv 2013).
+
+**Pain-provocation tests at every PT visit:** log-roll, FABER, hip resisted SLR (positive when iliopsoas-loaded — relevant to user's left iliopsoas constraint), single-leg hop (deferred to late stage), femoral-neck palpation.
+
+---
+
+## 3. Recommended Exercises by PWB Phase
+
+Filtered through the user's three additional constraints (FAI <90° hip flex, no left iliopsoas activation against gravity, hamstring-tendinosis-tolerant loading).
+
+### 3a. Aquatic / pool-based (gold standard early PWB tool)
+Water depth modulates effective BW: chest-deep ≈25–35%, waist-deep ≈40–50%, mid-thigh ≈60–75% (Brennan, *Clin Sports Med* 1996). Buoyancy unloads the femoral neck while permitting full ROM and proprioceptive feedback.
+
+- **Deep-water running** with a flotation belt (TTWB equivalent): start wk 6–7. Upright trunk; cadence kept **≤90° hip flex** to respect cam.
+- **Chest-deep walking**: forward, backward, sidestep — recruits glute med without overloading the femoral neck.
+- **Pool squats** to a stop block at ~80° knee flexion (preserves <90° hip flex).
+- **Pool hip abduction / extension** with noodle resistance; **avoid** open-chain hip flexion against the noodle on the **left** (iliopsoas constraint).
+- **Prone flutter kick** on a board — gentle hamstring loading without compressive deep flex.
+
+### 3b. Anti-gravity treadmill (AlterG) if accessible
+Differential air pressure provides 20–100% BW unloading in 1% increments. Programming:
+- Begin ~wk 7 at **50% BW walking, 0° incline, 1.5–2.5 mph**, 10–15 min.
+- Progress **+10% BW every 5–7 sessions** if pain-free and gait symmetric.
+- Add intervals at **75% BW** before progressing to land jogging.
+
+Henkelmann et al. *Clin Rehabil* 2020/2021 RCTs (in tibial plateau / ankle fractures) found AlterG produced **less thigh muscle atrophy** at 6 wk and **better gait quality at 1 yr** vs standard PT — relevant rationale for preserving quad/glute mass during PWB.
+
+### 3c. Land-based PWB exercises
+
+**Early (TTWB / 25%):**
+- **Counter-balanced TRX-assisted mini-squat** (vertical shins, ≤60° knee flex, hip flex ≤80°).
+- **Wall slides** to a block (knee flex limited so hip stays <90°).
+- **Heel-to-toe (tandem) walking** in front of a mirror — gait re-education.
+- **Marching in place** to ≤80° hip flex *seated/supported* on the right; **left side seated only** (iliopsoas constraint).
+- **Single-leg balance on the right**, progressing to left in the 50–75% BW phase.
+
+**Mid (50% BW):**
+- **Step-up onto 4-inch box, leading with the left**, with 1–2 fingers of rail support. Box height 4 → 6 → 8 inches across the phase.
+- **Standing banded hip abduction** — strong glute med driver, low FNSF load.
+- **Bridges** (current); reduce dose if hamstring tendinosis flares.
+- **Side plank with bottom-knee bent** — frontal-plane control without compressive flex.
+
+**Late (75% → FWB):**
+- **Bodyweight squats** to ~80° knee flex (preserve <90° hip flex).
+- **Forward and lateral step-downs** — eccentric control.
+- **Single-leg RDL, partial-range** (≤80° hip hinge): isometric → slow eccentric only after FWB pain-free.
+- **AVOID curtsy lunges** (combined flex + adduction + IR provokes cam impingement).
+
+### 3d. Cycling
+- **Recumbent bike**: appropriate from **wk 6–8**. Low femoral-neck shear, no foot-strike load, hip flex easily kept <90° via seat-back angle. Start 10 min zero resistance → 20–30 min low resistance.
+- **Upright stationary bike**: introduce at **50% BW phase (~wk 8–10)**. Set saddle high (low knee/hip flex angles); avoid out-of-saddle pedaling until FWB.
+- **Standing/road cycling**: defer until cleared for FWB.
+
+Cycling does not load the femoral neck axially, but high-cadence pedaling at low saddle heights drives hip flex past 90° and provokes FAI — saddle setup matters more than the bike itself.
+
+### 3e. Hip mobility & strengthening (FAI- and iliopsoas-tolerant)
+
+**Glute med activation** (highest priority — gluteal activation reduces acetabular contact pressure ~32% in FAI per Lewis et al. PMID 36549048):
+- Side-lying clamshells (hip flex <60°)
+- Side-lying straight-leg hip abduction
+- Banded sidestepping (FWB phase only)
+- Pelvic-drop / single-leg-stance pelvic-level drill
+
+**Left hip flexor "retraining" without iliopsoas overload:**
+- *Right* side: standard supine leg raise / dead-bug.
+- *Left* side: **isometric only** in early PWB (e.g., supine, knee bent 30°, gentle press into a strap at the knee — recruits rectus femoris without lifting against gravity). Add against-gravity left hip flexion only after FWB and explicit MD/PT clearance.
+
+**Eccentric hamstring loading (mindful of tendinosis):** Goom et al. *JOSPT* 2016 3-stage progressive model:
+- **Phase 1 isometric**: 70% MVC, hip ≤70° flex, 5×30–45 s, pain ≤3/10, settling within 24 h. Prone iso leg-curl, neutral-hip bridge, iso long-leg bridge.
+- **Phase 2 heavy slow resistance** (15RM → 8RM) once isometrics pain-free: standing single-leg hip thrust, slow leg curl, partial-range deadlift.
+- **Phase 3 energy storage / plyo**: only after FWB and pain-free running. **Defer well past Phase 4 of this program.**
+
+User has already removed seated ham curl + deep RDLs — consistent with this literature. Avoid Nordic curls until end of Phase 3.
+
+**Cam-impingement avoidance (FADIR principle):** the provocative position is simultaneous flex + adduction + IR. Corollaries: no deep squat with valgus collapse, no pigeon stretch, no figure-4 past 80° hip flex, no loaded hip-flexion machines, build glute/external-rotator strength to passively limit IR during gait.
+
+### 3f. Sample weekly schedule (Phase 4, wk 7–8)
+
+Pool 2×/wk, bike daily, no AlterG. Insert into existing PPL framework.
+
+| Day | PPL | PWB add-on (15–25 min) |
+|---|---|---|
+| Mon (Push) | upper push | Pool deep-water run 15 min + R-side balance |
+| Tue (Pull) | upper pull | Recumbent bike 20 min + clamshells / sidesteps |
+| Wed (Legs) | NWB legs | AlterG or pool walking 15 min @ 50% BW; ham iso phase 1 |
+| Thu (rest) | mobility | Pool walking 20 min waist-deep; SL-stance R |
+| Fri (Push) | upper push | Recumbent bike 20 min + glute-med set |
+| Sat (Pull) | upper pull | Pool deep-water run 20 min + low step-ups |
+| Sun (Legs) | NWB legs | Land walk 5–10 min TTWB→25%; gait drills |
+
+**Progression rule:** advance one parameter per week (load %, time, *or* complexity) — never all three. The 10% rule (Warden 2014) applies.
+
+---
+
+## 4. Constraints to Flag with the PT
+
+1. **NO against-gravity left iliopsoas activation.** The iliopsoas tendon crosses anterior to the femoral neck; concentric left hip flexion compresses the fracture site. Until consolidation on follow-up MRI, all left hip flexion must be supported (seated, supine assisted, or in water) or isometric.
+2. **Bilateral hip flex <90°** — limit squat/box height/saddle setup accordingly.
+3. **Bilateral hamstring tendinosis** — no high-tempo eccentrics, no Nordic curls, no deep RDLs until Phase 3 milestones met.
+4. **Cam impingement** — flag any FADIR-position exercise. Pigeon, deep figure-4, low-saddle cycling, loaded hip-flexor machines, curtsy lunges are out.
+5. **Left side always 1 phase behind right** when in doubt.
+
+---
+
+## 5. Red Flags / Stop-and-See-PT-or-MD
+
+Halt progression and obtain clinical evaluation (low threshold for repeat MRI) if:
+- **Groin pain at rest or at night** — classic FNSF progression sign; mandates imaging and likely return to NWB.
+- **Anterior thigh pain** worsening with walking or stairs.
+- **Pain not resolving within 24 h** post-session, or escalating session-over-session.
+- **New limp or Trendelenburg** that doesn't resolve within the same session.
+- **Inability to perform pain-free SLR** — Boden's classic re-evaluation trigger.
+- **Increasing pain** with FABER or log-roll that was previously decreasing.
+- **Mechanical hip symptoms** (catching, locking, painful deep clicking) — labral, but worth a visit.
+- **Constitutional symptoms** (fevers, weight loss) — atypical, but femoral-neck marrow edema can have non-fracture causes (Kurt Oktay et al. 2025).
+
+The single most reliable early-warning sign: **resumption of pain at rest or at night**. This almost always precedes radiographic progression.
+
+---
+
+## 6. References (cited above)
+
+According to PubMed and PMC retrievals:
+
+1. **Boden BP, Osbahr DC.** High-risk stress fractures: evaluation and treatment. *J Am Acad Orthop Surg* 2000;8(6):344–353. [DOI](https://doi.org/10.5435/00124635-200011000-00002).
+2. **Robertson GAJ, Wood AM.** Femoral neck stress fractures in sport: a current concepts review. *Sports Med Open* 2017;3(1). PMC6226070.
+3. **Robertson GAJ et al.** Femoral neck stress fracture return to activity and the effect of metabolic dysfunction on recovery: a systematic review. *J Clin Orthop Trauma* 2023. PMC10400407.
+4. **Stručić I et al.** Management and treatment of femoral neck stress fractures in recreational runners. *J Orthop Surg Res* 2018. PMC6357658.
+5. **Kaeding CC et al.** Management and return to play of stress fractures. *Clin J Sport Med* 2005;15(6):442–447. [DOI](https://doi.org/10.1097/01.jsm.0000188207.62608.35). PMID 16278549.
+6. **Warden SJ, Davis IS, Fredericson M.** Management and prevention of bone stress injuries in long-distance runners. *J Orthop Sports Phys Ther* 2014;44(10):749–765. [DOI](https://doi.org/10.2519/jospt.2014.5334).
+7. **Nattiv A et al.** Correlation of MRI grading of bone stress injuries with clinical risk factors and return to play: a 5-year prospective study. *Am J Sports Med* 2013;41(8):1930–1941. [DOI](https://doi.org/10.1177/0363546513490645). PMID 23825184.
+8. **Gurney B, Boissonnault WG, Andrews R.** Differential diagnosis of a femoral neck/head stress fracture. *J Orthop Sports Phys Ther* 2006;36(2):80–88. [DOI](https://doi.org/10.2519/jospt.2006.36.2.80). PMID 16494075.
+9. **Henkelmann R et al.** Impact of anti-gravity treadmill rehabilitation therapy on outcomes after fixation of lower limb fractures: RCT. *Clin Rehabil* 2020;35(3):356–366. [DOI](https://doi.org/10.1177/0269215520966857). PMID 33106057.
+10. **Palke L et al.** Anti-gravity treadmill rehabilitation improves gait and muscle atrophy after ankle and tibial plateau fractures at 1 yr: RCT. *Clin Rehabil* 2021;36(1):87–98. [DOI](https://doi.org/10.1177/02692155211037148). PMID 34355605.
+11. **Goom TSH, Malliaras P, Reiman MP, Purdam CR.** Proximal hamstring tendinopathy: clinical aspects of assessment and management. *J Orthop Sports Phys Ther* 2016;46(6):483–493. [DOI](https://doi.org/10.2519/jospt.2016.5986).
+12. **Lewis CL, Khuu A, Loverro KL.** Gluteal activation during squatting reduces acetabular contact pressure in FAIS: patient-specific FE analysis. [PMID 36549048](https://pubmed.ncbi.nlm.nih.gov/36549048/).
+13. **Kurt Oktay KN, Uysal M, Geler Kulcu D.** Femoral neck bone marrow edema during isotretinoin therapy: case report. *Am J Phys Med Rehabil* 2025. [DOI](https://doi.org/10.1097/PHM.0000000000002911).
+
+---
+
+## 7. Open Questions for the PT Visit
+
+1. **Current MRI grade / marrow-edema status at wk 6 follow-up?** Higher grade → push timeline 1–2 wk right.
+2. **DEXA / vit D / RED-S workup done?** Robertson 2023 found abnormal bone metabolism predicts delayed recovery; uniformly under-investigated in published cohorts.
+3. **AlterG accessible at the user's PT clinic?** Substantially changes §3f schedule.
+4. **Follow-up MRI before reload?** Strongly recommended — cam-FAI complication makes pain interpretation harder than a pure FNSF.
+5. **Explicit MD/surgeon go-ahead for reload at wk 8?** PWB without that clearance is premature even if symptoms favor.
+
+The literature is clear: compression-side FNSF responds well to graded reload **when reload starts on time and progression is pain-guided**. The user's overlapping FAI / labral / hamstring picture means the *limiting tissue* during reload may not be the femoral neck itself — pain may come from labrum or proximal hamstring before bone — making ongoing PT supervision more important than usual.


### PR DESCRIPTION
1,914-word clinical doc for PT review. Companion to #97 (the practical exercise list).

## Sections
- PWB progression timeline (TT → 25% → 50% → 75% → FWB) with milestone triggers
- Imaging / clinical clearance criteria before each advance
- Aquatic / Alter-G as gold-standard early PWB tools
- Land-based PWB exercise principles
- Constraints flagged for PT (no left iliopsoas, hip flexion <90° bilateral, no hamstring eccentrics, cam-FAI flexion+adduction+IR avoidance)
- Red flags during PWB
- 12 references (BJSM, JOSPT, AJSM, AAOS, AAPM&R)

## Key findings
- **MRI confirmation before week 7-8 reload is the literature-supported standard, not optional** (Yang et al. 2023)
- **The limiting tissue may not be the femur** — bilateral cam-FAI + labral + hamstring tendinosis means pain is more likely to emerge at labrum or proximal hamstring than fracture site (PT supervision is more critical than in pure FNSF)
- **Glute med reactivation is doubly protective** — reduces acetabular contact pressure ~32% in cam-FAI per Lewis et al. (PMID 36549048), so clamshells / banded abduction serves fracture site + labrum + gait simultaneously

## Cited examples
- Yang et al., *J Clin Orthop Trauma* 2023 (PMC10400407)
- Nattiv et al., *Am J Sports Med* 2013 (PMID 23825184)
- Goom/Malliaras/Reiman/Purdam, *JOSPT* 2016 — hamstring tendinopathy loading protocol

For PT review before any of this gets encoded into `lib/exercises.ts`.