### PR TITLE
feat(condition): add Exercise.movementTags + isAllowedForCondition predicate

### DIFF
--- a/lib/condition-filter.ts
+++ b/lib/condition-filter.ts
@@ -9,8 +9,8 @@
 // untagged majority.
 // =============================================================================
 
-import type { Condition, MovementTag } from "@/lib/condition-types";
-import type { Exercise } from "@/lib/exercises";
+import type { Condition, MovementTag } from "./condition-types";
+import type { Exercise } from "./exercises";
 
 export interface ConditionFilterResult {
   allowed: boolean;

--- a/lib/condition-filter.ts
+++ b/lib/condition-filter.ts
@@ -1,0 +1,121 @@
+// =============================================================================
+// CONDITION FILTER
+// =============================================================================
+//
+// Predicate for "is this exercise allowed for this condition in this phase."
+// Untagged exercises default to allowed so behavior is unchanged during the
+// MovementTag migration. Once exercises are tagged, the predicate becomes
+// the single safety gate; today it's a forward-compatible no-op for the
+// untagged majority.
+// =============================================================================
+
+import type { Condition, MovementTag } from "@/lib/condition-types";
+import type { Exercise } from "@/lib/exercises";
+
+export interface ConditionFilterResult {
+  allowed: boolean;
+  level: "safe" | "caution" | "danger";
+  /** When `allowed: false`, the first forbidden tag that tripped the filter. */
+  blockedBy?: MovementTag;
+  /** Human-readable explanation. */
+  rationale: string;
+}
+
+/**
+ * Resolve effective tag sets for a phase by composing condition-level
+ * forbidden/caution lists with phase-level unlock/restrict overrides.
+ */
+function resolvePhaseTags(
+  condition: Condition,
+  currentPhaseId: string,
+): {
+  forbidden: Set<MovementTag>;
+  caution: Set<MovementTag>;
+} {
+  const phase = condition.program.phases.find((p) => p.id === currentPhaseId);
+  const unlocked = new Set<MovementTag>(phase?.unlockTags ?? []);
+  const restricted = new Set<MovementTag>(phase?.restrictTags ?? []);
+
+  const forbidden = new Set<MovementTag>(
+    condition.constraints.forbiddenTags.filter((t) => !unlocked.has(t)),
+  );
+  for (const t of restricted) forbidden.add(t);
+
+  const caution = new Set<MovementTag>(
+    condition.constraints.cautionTags.filter(
+      (t) => !unlocked.has(t) && !forbidden.has(t),
+    ),
+  );
+
+  return { forbidden, caution };
+}
+
+/**
+ * Core predicate. Operates on a tag list so it can be reused for both
+ * `Exercise.movementTags` and ad-hoc tag lists (e.g. AI-suggested exercises
+ * that aren't in the global `EX` table yet).
+ *
+ * Untagged inputs (`exerciseTags.length === 0`) return allowed=safe with a
+ * rationale that names the missing-tag default so callers can decide whether
+ * to log a warning during the migration window.
+ */
+export function isAllowedByTags(args: {
+  exerciseTags: MovementTag[];
+  condition: Condition;
+  currentPhaseId: string;
+}): ConditionFilterResult {
+  const { exerciseTags, condition, currentPhaseId } = args;
+
+  if (exerciseTags.length === 0) {
+    return {
+      allowed: true,
+      level: "safe",
+      rationale: "exercise has no movementTags — default-allow during migration",
+    };
+  }
+
+  const { forbidden, caution } = resolvePhaseTags(condition, currentPhaseId);
+
+  for (const tag of exerciseTags) {
+    if (forbidden.has(tag)) {
+      return {
+        allowed: false,
+        level: "danger",
+        blockedBy: tag,
+        rationale: `Exercise demands ${tag}, which is forbidden for ${condition.metadata.displayName} in this phase.`,
+      };
+    }
+  }
+
+  for (const tag of exerciseTags) {
+    if (caution.has(tag)) {
+      return {
+        allowed: true,
+        level: "caution",
+        rationale: `Exercise demands ${tag}, which is provisionally allowed for ${condition.metadata.displayName} but warrants caution.`,
+      };
+    }
+  }
+
+  return {
+    allowed: true,
+    level: "safe",
+    rationale: "All movement tags clear for this condition + phase.",
+  };
+}
+
+/**
+ * Convenience wrapper that pulls tags off an `Exercise`. Equivalent to
+ * `isAllowedByTags({ exerciseTags: ex.movementTags ?? [], ... })`.
+ */
+export function isAllowedForCondition(
+  exercise: Exercise,
+  condition: Condition,
+  currentPhaseId: string,
+): ConditionFilterResult {
+  return isAllowedByTags({
+    exerciseTags: exercise.movementTags ?? [],
+    condition,
+    currentPhaseId,
+  });
+}

--- a/lib/exercises.ts
+++ b/lib/exercises.ts
@@ -44,6 +44,8 @@ export interface ExerciseMuscles {
   secondary?: string[];
 }
 
+import type { MovementTag } from "@/lib/condition-types";
+
 export interface ExerciseConstraints {
   requiresIliopsoas: boolean;
   maxHipFlexion: number;
@@ -96,6 +98,13 @@ export interface Exercise {
   cableSuperset?: boolean;
   constraints: ExerciseConstraints;
   muscles: ExerciseMuscles;
+  /**
+   * Biomechanical demands of this exercise. When populated, exercises become
+   * filterable per-condition via `isAllowedForCondition()` in
+   * `lib/condition-filter.ts`. Optional during the migration: untagged
+   * exercises default to "allowed" so existing behavior is unchanged.
+   */
+  movementTags?: MovementTag[];
 }
 
 export interface EquipmentItem {

--- a/lib/exercises.ts
+++ b/lib/exercises.ts
@@ -44,7 +44,7 @@ export interface ExerciseMuscles {
   secondary?: string[];
 }
 
-import type { MovementTag } from "@/lib/condition-types";
+import type { MovementTag } from "./condition-types";
 
 export interface ExerciseConstraints {
   requiresIliopsoas: boolean;


### PR DESCRIPTION
## Summary

Move 2a of the genericization roadmap. Adds the type infrastructure for per-condition exercise filtering without touching the actual exercise records. **Untagged exercises (all 114 today) default to allowed=safe so behavior is unchanged.**

Move 2b will be the bulk-tagging pass on \`lib/exercises.ts\` — that needs clinical review on every tag and is intentionally a separate PR.

## What changed

- **\`lib/exercises.ts\`** — imports \`MovementTag\` from condition-types; adds optional \`movementTags?: MovementTag[]\` on \`Exercise\`.
- **\`lib/condition-filter.ts\` (NEW)** — \`isAllowedByTags()\` core predicate + \`isAllowedForCondition()\` Exercise-aware wrapper. Resolves phase-level unlock/restrict overrides against the condition's forbiddenTags + cautionTags. Returns \`{ allowed, level, blockedBy?, rationale }\` matching the \`ExerciseSafetyPredicate\` signature from the schema.

## Predicate semantics (verified locally — 5/5 passing)

| Case | Tags | Phase | Expected |
|---|---|---|---|
| Untagged | \`[]\` | foundation | allowed safe (default-allow during migration) |
| Forbidden tag | \`iliopsoas_recruitment_high\` | foundation | blocked danger |
| Caution tag | \`single_leg_balance\` | foundation | allowed caution |
| Phase-locked, foundation | \`weight_bearing_unilateral\` | foundation | blocked danger |
| Phase-locked, unlocked | \`weight_bearing_unilateral\` | pwb_prep | allowed safe (unlock wins) |

The phase-unlock semantics specifically: \`fnsfLeft.program.phases[3].unlockTags\` includes \`weight_bearing_unilateral\` and \`weight_bearing_bilateral\`, so PWB Prep allows what foundation forbids.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`npm run build\` clean
- [x] 5/5 predicate smoke cases pass
- [ ] Playwright suite passes on CI (no e2e exercises this code yet — it's pure substrate)
- [ ] Vercel preview deploys cleanly

## Sequence

Stacked on #102 (which is already merged to \`dev\`). This PR is rebased on \`dev\` directly and has no dependencies on open work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)