### PR TITLE
feat(watch): 8wk / 4-phase schedule sync for PWB Prep

### DIFF
--- a/watch/app/src/main/kotlin/com/nwb/watch/data/ExerciseRepository.kt
+++ b/watch/app/src/main/kotlin/com/nwb/watch/data/ExerciseRepository.kt
@@ -12,7 +12,7 @@ import javax.inject.Singleton
 
 /**
  * Loads and caches exercise/workout/supplement data from bundled JSON resources.
- * All data is static for the 6-week program — loaded once at app start.
+ * All data is static for the 8-week program — loaded once at app start.
  */
 @Singleton
 class ExerciseRepository @Inject constructor(

--- a/watch/app/src/main/kotlin/com/nwb/watch/data/WorkoutScheduler.kt
+++ b/watch/app/src/main/kotlin/com/nwb/watch/data/WorkoutScheduler.kt
@@ -13,7 +13,7 @@ private val DEFAULT_PROGRAM_START: LocalDate = LocalDate.of(2026, 3, 17)
 
 /**
  * Determines today's workout and current training phase based on
- * the 7-day schedule rotation and 6-week program timeline.
+ * the 7-day schedule rotation and 8-week program timeline.
  *
  * Stateless — the start date comes from DataStore via [WorkoutState].
  * Callers read the stored epoch, resolve it with [programStartDate],
@@ -41,17 +41,24 @@ class WorkoutScheduler @Inject constructor(
     fun programDay(today: LocalDate, startDate: LocalDate): Int =
         ChronoUnit.DAYS.between(startDate, today).toInt().coerceAtLeast(0)
 
-    /** Current week number (1-indexed, capped at 6). */
+    /** Current week number (1-indexed, capped at 8). */
     fun currentWeek(today: LocalDate, startDate: LocalDate): Int =
-        (programDay(today, startDate) / 7 + 1).coerceIn(1, 6)
+        (programDay(today, startDate) / 7 + 1).coerceIn(1, 8)
 
-    /** Current phase index (0 = Foundation, 1 = Build, 2 = Peak). */
+    /**
+     * Current phase index. Mirrors `lib/program.ts` `computeCurrentPhase`:
+     *  - 0 = Foundation (weeks 1-2)
+     *  - 1 = Build (weeks 3-4)
+     *  - 2 = Peak (weeks 5-6)
+     *  - 3 = PWB Prep (weeks 7-8)
+     */
     fun currentPhaseIndex(today: LocalDate, startDate: LocalDate): Int {
         val week = currentWeek(today, startDate)
         return when {
             week <= 2 -> 0
             week <= 4 -> 1
-            else -> 2
+            week <= 6 -> 2
+            else -> 3
         }
     }
 
@@ -86,9 +93,9 @@ class WorkoutScheduler @Inject constructor(
             currentPhaseIndex(today, startDate),
         )
 
-    /** Total program progress as a fraction (0.0 to 1.0). */
+    /** Total program progress as a fraction (0.0 to 1.0). 8 weeks = 56 days. */
     fun programProgress(today: LocalDate, startDate: LocalDate): Float =
-        (programDay(today, startDate).toFloat() / 42f).coerceIn(0f, 1f)
+        (programDay(today, startDate).toFloat() / 56f).coerceIn(0f, 1f)
 
     /**
      * Given a target week number, compute the start date that would
@@ -96,7 +103,7 @@ class WorkoutScheduler @Inject constructor(
      * past Monday, and each earlier week subtracts 7 days.
      */
     fun startDateForWeek(week: Int, today: LocalDate = LocalDate.now()): LocalDate {
-        val clamped = week.coerceIn(1, 6)
+        val clamped = week.coerceIn(1, 8)
         return findNearestPastMonday(today).minusWeeks((clamped - 1).toLong())
     }
 }

--- a/watch/app/src/main/kotlin/com/nwb/watch/ui/settings/SettingsScreen.kt
+++ b/watch/app/src/main/kotlin/com/nwb/watch/ui/settings/SettingsScreen.kt
@@ -133,7 +133,7 @@ private fun WeekPicker(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterHorizontally),
         ) {
-            (1..3).forEach { week ->
+            (1..4).forEach { week ->
                 WeekButton(week, currentWeek == week, onPick)
             }
         }
@@ -142,7 +142,7 @@ private fun WeekPicker(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterHorizontally),
         ) {
-            (4..6).forEach { week ->
+            (5..8).forEach { week ->
                 WeekButton(week, currentWeek == week, onPick)
             }
         }

--- a/watch/app/src/main/res/raw/workouts.json
+++ b/watch/app/src/main/res/raw/workouts.json
@@ -61,6 +61,12 @@
       "name": "Peak",
       "color": "#f97316",
       "desc": "Maximum safe output. Heavy singles. Pre-weight-bearing."
+    },
+    {
+      "weeks": "7-8",
+      "name": "PWB Prep",
+      "color": "#10b981",
+      "desc": "Partial weight bearing transition. PT-guided progression. New exercises being added."
     }
   ],
   "workouts": {


### PR DESCRIPTION
## Summary

The Wear OS watch app's scheduler was hardcoded to the original 6-week / 3-phase plan. The PWA moved to 8 weeks / 4 phases (commit `202a16b`, with PWB Prep additions in `a274001`/`9cc924f`). This PR brings the watch into alignment so PWB-Prep weeks (7-8) don't silently render as Peak prescriptions.

- `WorkoutScheduler.kt`: week clamp 6 → 8, phase logic adds a 4th case (`week <= 6 -> 2`, `else -> 3`), `programProgress` divisor 42f → 56f, `startDateForWeek` clamp 1..6 → 1..8. Mirrors `lib/program.ts::computeCurrentPhase` exactly.
- `SettingsScreen.kt`: `WeekPicker` rows now show weeks 1-4 / 5-8 (was 1-3 / 4-6) so the user can self-correct into the new weeks.
- `ExerciseRepository.kt`: doc comment 6-week → 8-week.
- `workouts.json`: appends the 4th `phases[]` entry (`PWB Prep`, color `#10b981`, weeks 7-8) — verbatim copy of `PHASES` in `lib/exercises.ts`. Without this, `currentPhase()` would silently fall back to `phases.lastIndex` (Peak) for week-7+ users.

`PROG_START` (2026-03-17) still matches `DEFAULT_PROGRAM_START` in the scheduler — no date change needed.

## Test plan

- [ ] CI: `Wear OS App Build` passes (Gradle `:app:assembleDebug` on JDK 17 — the local checkout has no Android SDK, so this is the primary signal).
- [ ] CI: `Playwright Tests` unchanged (no PWA code touched).
- [ ] Manual once installed: open Settings → "I'm on Week" picker shows 1-8; the program-progress text correctly reads 0% on day 0 and 100% on day 56; week 7 surfaces the green PWB-Prep phase label.

## Out of scope

- Re-running `watch/scripts/export-data.ts` to refresh `exercises.json` with the new `phase: 3` PWB exercises. The JSON-export pipeline runs in the CI step `Export exercise data for watch` before the Gradle build, so the bundled APK will pick up new PWB exercises automatically once `lib/exercises.ts` finalizes them. This PR only fixes the *scheduler* — the data layer was already phase-aware.
- The `wip/watch-sync-recovery` Vercel-Blob sync work (separate PR per ops-review §2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)