### PR TITLE
feat(pt): surface left-leg conditioning PT inline under main lifts

### DIFF
--- a/components/complement-picker.tsx
+++ b/components/complement-picker.tsx
@@ -11,16 +11,23 @@ import {
   type NearbySuperset,
   type MobilitySupplement,
 } from "@/lib/supplements";
+import {
+  getLeftLegConditioningPT,
+  type RehabPhase,
+} from "@/lib/pt-exercises";
+import { loadState } from "@/lib/storage";
 import { cssAlpha } from "@/lib/css-utils";
 
 /**
- * A complement the user can add to an exercise. There are four kinds:
+ * A complement the user can add to an exercise. There are five kinds:
  *  - "nearby"   — one of NEARBY_SUPERSETS (needs nearby equipment)
  *  - "supp"     — a left-leg supplement (looked up in SUPPLEMENT_EX by name)
  *  - "core"     — a core drill from SUPPLEMENT_CORE for the current workout day
  *                 (also looked up in SUPPLEMENT_EX by name; distinct kind so it
  *                 can render with a CORE label + region color)
  *  - "mobility" — a zero-equipment mobility / stretch / breathing drill
+ *  - "pt"       — a phase-gated PT exercise from PT_EXERCISES (left-leg
+ *                 conditioning surface; filtered by current nwb_pt_phase)
  */
 export type ComplementId = string;
 
@@ -38,9 +45,12 @@ export function encodeCoreId(name: string): ComplementId {
 export function encodeMobilityId(m: MobilitySupplement): ComplementId {
   return `mob${SEP}${m.id}`;
 }
+export function encodePTId(ptId: string): ComplementId {
+  return `pt${SEP}${ptId}`;
+}
 
 export function decodeComplement(id: ComplementId): {
-  kind: "nearby" | "supp" | "core" | "mobility";
+  kind: "nearby" | "supp" | "core" | "mobility" | "pt";
   value: string;
   sub?: string;
 } {
@@ -55,6 +65,9 @@ export function decodeComplement(id: ComplementId): {
   }
   if (kind === "core") {
     return { kind: "core", value: rest.join(sep) };
+  }
+  if (kind === "pt") {
+    return { kind: "pt", value: rest.join(sep) };
   }
   return { kind: "supp", value: rest.join(sep) };
 }
@@ -152,7 +165,12 @@ export default function ComplementPicker({
 }: ComplementPickerProps) {
   const activeSet = useMemo(() => new Set(activeIds), [activeIds]);
 
-  const { nearbyAvail, suppAvail, coreAvail, coreSubtitle, mobilityAvail } = useMemo(() => {
+  const ptPhase = useMemo<RehabPhase>(
+    () => loadState<RehabPhase>("nwb_pt_phase", "TTWB"),
+    [],
+  );
+
+  const { nearbyAvail, suppAvail, ptAvail, coreAvail, coreSubtitle, mobilityAvail } = useMemo(() => {
     const inUseIds = new Set(
       exerciseRequires.map((r) => EQUIP_TO_NEARBY[r]).filter(Boolean),
     );
@@ -169,6 +187,8 @@ export default function ComplementPicker({
       name: string;
       data: (typeof SUPPLEMENT_EX)[string];
     }>;
+
+    const ptAvail = getLeftLegConditioningPT(ptPhase);
 
     const coreDay = workoutKey ? SUPPLEMENT_CORE[workoutKey] : null;
     const coreAvail = (coreDay?.exercises ?? [])
@@ -188,12 +208,13 @@ export default function ComplementPicker({
       m.appliesTo.includes(exerciseCategory as "push" | "pull" | "legs" | "core" | "cardio"),
     );
 
-    return { nearbyAvail, suppAvail, coreAvail, coreSubtitle, mobilityAvail };
-  }, [exerciseRequires, exerciseCategory, workoutKey, nearbySelections]);
+    return { nearbyAvail, suppAvail, ptAvail, coreAvail, coreSubtitle, mobilityAvail };
+  }, [exerciseRequires, exerciseCategory, workoutKey, nearbySelections, ptPhase]);
 
   const hasAny =
     nearbyAvail.length > 0 ||
     suppAvail.length > 0 ||
+    ptAvail.length > 0 ||
     coreAvail.length > 0 ||
     mobilityAvail.length > 0;
 
@@ -329,6 +350,35 @@ export default function ComplementPicker({
                       title={name}
                       sets={`${sets[0]}\u00D7${sets[1]}`}
                       description={data.execution}
+                      active={activeSet.has(id)}
+                      onClick={() => onToggle(id)}
+                    />
+                  );
+                })}
+              </div>
+            </>
+          )}
+
+          {ptAvail.length > 0 && (
+            <>
+              <div className="text-[10px] font-bold text-text-muted uppercase tracking-wider mb-2">
+                PT \u2014 Left-leg conditioning ({ptAvail.length})
+              </div>
+              <div className="text-[10px] text-text-muted mb-2 leading-snug">
+                Phase: <strong>{ptPhase}</strong> &mdash; phase-gated PT
+                progression. Switch phase from the Rehab tab.
+              </div>
+              <div className="space-y-1.5 mb-4">
+                {ptAvail.map((ex) => {
+                  const id = encodePTId(ex.id);
+                  return (
+                    <ComplementButton
+                      key={id}
+                      label="PT"
+                      color="#34d399"
+                      title={ex.name}
+                      sets={ex.sets}
+                      description={ex.execution}
                       active={activeSet.has(id)}
                       onClick={() => onToggle(id)}
                     />

--- a/components/workout-view.tsx
+++ b/components/workout-view.tsx
@@ -42,6 +42,7 @@ import ComplementPicker, {
   encodeSuppId,
   type ComplementId,
 } from "@/components/complement-picker";
+import { PT_EXERCISES } from "@/lib/pt-exercises";
 import { useLongPress } from "@/lib/use-long-press";
 import { cssAlpha } from "@/lib/css-utils";
 import HevyImportPanel from "@/components/hevy-import-panel";
@@ -1059,6 +1060,21 @@ export default function WorkoutView() {
             removable: true,
             complementId: id,
           });
+        } else if (decoded.kind === "pt") {
+          const pt = PT_EXERCISES[decoded.value];
+          if (!pt) continue;
+          cards.push({
+            key: id,
+            kind: "leftleg",
+            label: "PT",
+            color: "#34d399",
+            title: pt.name,
+            sets: pt.sets,
+            instruction: pt.execution,
+            safety: pt.ptCues,
+            removable: true,
+            complementId: id,
+          });
         }
       }
 
@@ -1343,6 +1359,16 @@ export default function WorkoutView() {
                   sets: m.sets,
                   instruction: m.instruction,
                   safety: m.safety,
+                });
+              } else if (decoded.kind === "pt") {
+                const pt = PT_EXERCISES[decoded.value];
+                if (!pt) continue;
+                supps.push({
+                  type: "leftleg",
+                  name: pt.name,
+                  sets: pt.sets,
+                  instruction: pt.execution,
+                  safety: pt.ptCues,
                 });
               }
             }

--- a/lib/pt-exercises.ts
+++ b/lib/pt-exercises.ts
@@ -728,3 +728,37 @@ export function groupPTByCategory(
   }
   return out;
 }
+
+/**
+ * Categories that surface as inline "left-leg conditioning" supplements
+ * under main lifts. Excludes closed-chain-bilateral, step-work, balance,
+ * and gait-drills — those are standalone Rehab-tab work, not interleaved.
+ */
+const LEFT_LEG_CONDITIONING_CATEGORIES: PTCategory[] = [
+  "glute-activation",
+  "quad-activation",
+  "hip-rotator",
+  "calf",
+];
+
+const LEFT_LEG_CONDITIONING_SIDES: PTSide[] = [
+  "left",
+  "bilateral",
+  "weight-shifted-left",
+];
+
+/**
+ * Phase-appropriate PT exercises suitable for inline interleaving with main
+ * lifts (left-leg conditioning supplements). Filters PT_EXERCISES by:
+ *   - phase ∈ current rehab phase
+ *   - category ∈ glute / quad / hip-rotator / calf
+ *   - side loads the left or both legs (no pure right-side drills)
+ */
+export function getLeftLegConditioningPT(phase: RehabPhase): PTExercise[] {
+  return Object.values(PT_EXERCISES).filter(
+    (ex) =>
+      ex.phase.includes(phase) &&
+      LEFT_LEG_CONDITIONING_CATEGORIES.includes(ex.category) &&
+      LEFT_LEG_CONDITIONING_SIDES.includes(ex.side),
+  );
+}


### PR DESCRIPTION
## Summary

Surfaces phase-gated PT exercises (from `lib/pt-exercises.ts`, just merged via #106 + #108) inline under main lifts via the existing complement picker. Previously the only way to see PT drills was the Rehab tab — now they show up alongside the legacy `SUPPLEMENT_LEFT_LEG` interleave for matching workouts.

## How it filters

`getLeftLegConditioningPT(phase)` returns `PT_EXERCISES` entries where:

- `phase` ∈ user's current `nwb_pt_phase` (read from localStorage; same key the Rehab tab writes)
- `category` ∈ `glute-activation`, `quad-activation`, `hip-rotator`, `calf`
- `side` loads the left or both legs

Closed-chain bilateral, step-work, balance, and gait drills are **intentionally excluded** from this surface — they're standalone Rehab-tab work, not interleaved between sets.

## Files

- `lib/pt-exercises.ts` — new `getLeftLegConditioningPT(phase)` helper
- `components/complement-picker.tsx` — new `pt` complement kind (`encodePTId` + `decodeComplement` extension) and a new "PT — Left-leg conditioning ({phase})" section with emerald PT badge to match the Rehab tab
- `components/workout-view.tsx` — `pt` branch added to both `decodeComplement` consumers (inline card render + focus-mode supplements builder)

## Test plan

- [x] `npm run build` exits 0
- [ ] Manual: open the complement picker on a main exercise, confirm "PT — Left-leg conditioning" section appears with current phase
- [ ] Manual: toggle a PT entry, confirm it interleaves under the lift with emerald PT badge
- [ ] Manual: switch phase in Rehab tab, reopen picker, confirm exercise list updates
- [ ] Manual: focus-mode walkthrough surfaces toggled PT supplements

## Notes

This implements approach (A) from issue #104 / #108 follow-ups (cleaner filtering vs. duplicating data into `SUPPLEMENT_EX`). It's additive — legacy `SUPPLEMENT_LEFT_LEG.base` / `.legsExtra` keeps working unchanged.

https://claude.ai/code/session_014ptfgmc5zrrywY9hBy58Zn

---
_Generated by [Claude Code](https://claude.ai/code/session_014ptfgmc5zrrywY9hBy58Zn)_