### PR TITLE
feat(auth): cloud-sync workout history + decouple login from AI flag

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,5 +1,9 @@
 # Feature flags
 NEXT_PUBLIC_FEATURE_AI_SUGGESTIONS=false
+# Gates the Sign-in button + cloud workout sync. Independent of AI suggestions.
+# Requires Google OAuth creds (below) and the workout_sessions table from
+# db/schema.sql to be applied against POSTGRES_URL before turning on.
+NEXT_PUBLIC_FEATURE_AUTH=false
 
 # AI (placeholder — set in Vercel dashboard when ready)
 ANTHROPIC_API_KEY=

--- a/app/api/workout-sessions/route.ts
+++ b/app/api/workout-sessions/route.ts
@@ -1,0 +1,151 @@
+// Auth-gated CRUD for the per-user workout history.
+//
+// Conflict policy: last-write-wins per session id, by `updated_at`.
+// Active / in-progress sessions are NOT pushed here — they stay client-side
+// until endSession() runs, then a single PUT lands the finished session.
+//
+// Routes:
+//   GET    /api/workout-sessions[?since=<epoch ms>]
+//     → { sessions: WorkoutSession[] } for the signed-in user. `since`
+//       filters to rows with updated_at strictly newer than the timestamp
+//       (used for incremental pull).
+//   PUT    /api/workout-sessions
+//     body: { sessions: WorkoutSession[] }
+//     → upserts each session. Returns { upserted: number, skipped: number }.
+//       Skipped = stored row's updated_at is newer than incoming.
+//   DELETE /api/workout-sessions?id=<session-id>
+//     → tombstone delete (idempotent).
+
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { auth } from "@/lib/auth";
+import type { WorkoutSession } from "@/lib/workout-log";
+
+interface SessionRow {
+  id: string;
+  workout_key: string;
+  started_at: string; // numeric → string from pg
+  ended_at: string | null;
+  data: WorkoutSession;
+  updated_at: string; // ISO timestamp
+}
+
+export async function GET(req: NextRequest) {
+  const session = await auth();
+  const userId = (session?.user as { email?: string } | undefined)?.email;
+  if (!session || !userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const sinceParam = req.nextUrl.searchParams.get("since");
+  const since = sinceParam ? Number(sinceParam) : null;
+
+  let rows;
+  if (since != null && Number.isFinite(since)) {
+    rows = await sql<SessionRow>`
+      SELECT id, workout_key, started_at, ended_at, data, updated_at
+        FROM workout_sessions
+       WHERE user_id = ${userId}
+         AND EXTRACT(EPOCH FROM updated_at) * 1000 > ${since}
+       ORDER BY started_at DESC
+    `;
+  } else {
+    rows = await sql<SessionRow>`
+      SELECT id, workout_key, started_at, ended_at, data, updated_at
+        FROM workout_sessions
+       WHERE user_id = ${userId}
+       ORDER BY started_at DESC
+    `;
+  }
+
+  return NextResponse.json({
+    sessions: rows.rows.map((r) => r.data),
+    serverNow: Date.now(),
+  });
+}
+
+export async function PUT(req: NextRequest) {
+  const session = await auth();
+  const userId = (session?.user as { email?: string } | undefined)?.email;
+  if (!session || !userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: { sessions?: WorkoutSession[] };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const incoming = Array.isArray(body.sessions) ? body.sessions : [];
+  if (incoming.length === 0) {
+    return NextResponse.json({ upserted: 0, skipped: 0 });
+  }
+
+  let upserted = 0;
+  let skipped = 0;
+
+  for (const ws of incoming) {
+    if (!ws.id || !ws.workoutKey || typeof ws.startedAt !== "number") {
+      skipped++;
+      continue;
+    }
+    // Last-write-wins by client-supplied wall time (endedAt || max set
+    // completedAt || startedAt). The DB updated_at trigger always reflects
+    // server insert/update time, but we use the client clock as the LWW
+    // timestamp because cross-device merges should respect when the user
+    // actually finished the work, not when the device managed to sync.
+    const clientWallMs = clientWatermark(ws);
+
+    const result = await sql`
+      INSERT INTO workout_sessions
+        (id, user_id, workout_key, started_at, ended_at, data)
+      VALUES
+        (${ws.id}, ${userId}, ${ws.workoutKey},
+         ${ws.startedAt}, ${ws.endedAt ?? null}, ${JSON.stringify(ws)}::jsonb)
+      ON CONFLICT (id) DO UPDATE
+         SET workout_key = EXCLUDED.workout_key,
+             started_at  = EXCLUDED.started_at,
+             ended_at    = EXCLUDED.ended_at,
+             data        = EXCLUDED.data
+       WHERE workout_sessions.user_id = ${userId}
+         AND ${clientWallMs} >= COALESCE(
+               EXTRACT(EPOCH FROM workout_sessions.updated_at) * 1000,
+               0
+             )
+      RETURNING id
+    `;
+
+    if (result.rowCount && result.rowCount > 0) upserted++;
+    else skipped++;
+  }
+
+  return NextResponse.json({ upserted, skipped });
+}
+
+export async function DELETE(req: NextRequest) {
+  const session = await auth();
+  const userId = (session?.user as { email?: string } | undefined)?.email;
+  if (!session || !userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const id = req.nextUrl.searchParams.get("id");
+  if (!id) {
+    return NextResponse.json({ error: "id required" }, { status: 400 });
+  }
+
+  await sql`
+    DELETE FROM workout_sessions
+     WHERE id = ${id} AND user_id = ${userId}
+  `;
+  return NextResponse.json({ ok: true });
+}
+
+function clientWatermark(ws: WorkoutSession): number {
+  const setMax = ws.exercises
+    .flatMap((e) => e.sets)
+    .reduce((acc, s) => Math.max(acc, s.completedAt), 0);
+  return Math.max(ws.endedAt ?? 0, setMax, ws.startedAt);
+}

--- a/components/auth-button.tsx
+++ b/components/auth-button.tsx
@@ -1,10 +1,31 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useSession, signIn, signOut } from "next-auth/react";
+import {
+  loadSyncState,
+  syncWorkoutSessions,
+  type SyncState,
+} from "@/lib/workout-sync";
 
 export default function AuthButton() {
   const { data: session, status } = useSession();
+  const [syncState, setSyncState] = useState<SyncState>(() => loadSyncState());
+  const didInitialSync = useRef(false);
+
+  // First successful auth → run a full pull-merge-push.
+  useEffect(() => {
+    if (status !== "authenticated" || didInitialSync.current) return;
+    didInitialSync.current = true;
+    syncWorkoutSessions().then(() => setSyncState(loadSyncState()));
+  }, [status]);
+
+  // Refresh the indicator periodically (cheap localStorage read).
+  useEffect(() => {
+    if (status !== "authenticated") return;
+    const t = setInterval(() => setSyncState(loadSyncState()), 5000);
+    return () => clearInterval(t);
+  }, [status]);
 
   if (status === "loading") {
     return (
@@ -16,17 +37,32 @@ export default function AuthButton() {
   }
 
   if (session?.user) {
+    const dotColor = syncState.lastError
+      ? "#ef4444"
+      : syncState.inFlight
+        ? "#f59e0b"
+        : syncState.lastSyncAt > 0
+          ? "#10b981"
+          : "var(--color-border)";
+    const tooltip = syncState.lastError
+      ? `Sync error: ${syncState.lastError}`
+      : syncState.inFlight
+        ? "Syncing…"
+        : syncState.lastSyncAt > 0
+          ? `Last sync ${new Date(syncState.lastSyncAt).toLocaleTimeString()}`
+          : "Not yet synced";
     return (
       <button
         onClick={() => signOut()}
-        className="flex items-center gap-2 rounded-full cursor-pointer min-h-[44px] min-w-[44px] px-1"
+        className="relative flex items-center gap-2 rounded-full cursor-pointer min-h-[44px] min-w-[44px] px-1"
         style={{
           background: "none",
           border: "none",
         }}
-        title="Sign out"
+        title={`Sign out — ${tooltip}`}
       >
         {session.user.image ? (
+          // eslint-disable-next-line @next/next/no-img-element
           <img
             src={session.user.image}
             alt={session.user.name ?? "User avatar"}
@@ -46,6 +82,14 @@ export default function AuthButton() {
             {(session.user.name ?? "U")[0].toUpperCase()}
           </div>
         )}
+        <span
+          aria-label={tooltip}
+          className="absolute bottom-0 right-0 w-2.5 h-2.5 rounded-full"
+          style={{
+            background: dotColor,
+            border: "2px solid var(--color-bg)",
+          }}
+        />
       </button>
     );
   }

--- a/components/history-view.tsx
+++ b/components/history-view.tsx
@@ -7,7 +7,16 @@ import {
   type LoggedSet,
   type WorkoutSession,
 } from "@/lib/workout-log";
+import {
+  loadSyncState,
+  syncWorkoutSessions,
+  type SyncState,
+} from "@/lib/workout-sync";
 import { EX } from "@/lib/exercises";
+
+const AUTH_ENABLED =
+  process.env.NEXT_PUBLIC_FEATURE_AUTH === "true" ||
+  process.env.NEXT_PUBLIC_FEATURE_AI_SUGGESTIONS === "true";
 
 /**
  * History view — shows previously completed (archived) workout sessions
@@ -20,14 +29,27 @@ import { EX } from "@/lib/exercises";
 export default function HistoryView() {
   const [sessions, setSessions] = useState<WorkoutSession[]>([]);
   const [hydrated, setHydrated] = useState(false);
+  const [syncState, setSyncState] = useState<SyncState>(() => ({
+    lastSyncAt: 0,
+    lastError: null,
+    inFlight: false,
+  }));
 
   // Hydrate from localStorage on mount. We read once — when the user logs
   // a new session, they'll come back to this tab and we re-mount via the
   // tab switch which triggers a fresh read.
   useEffect(() => {
     setSessions(loadSessions());
+    setSyncState(loadSyncState());
     setHydrated(true);
   }, []);
+
+  const handleSyncNow = async () => {
+    setSyncState((s) => ({ ...s, inFlight: true }));
+    await syncWorkoutSessions();
+    setSessions(loadSessions());
+    setSyncState(loadSyncState());
+  };
 
   const ordered = useMemo(() => {
     // Reverse-chronological by endedAt (fallback startedAt for anything
@@ -66,14 +88,67 @@ export default function HistoryView() {
 
   return (
     <div data-testid="history-view" className="flex flex-col gap-3">
-      <div className="text-[11px] uppercase tracking-wider font-bold text-text-muted px-1">
-        {ordered.length} {ordered.length === 1 ? "session" : "sessions"} logged
+      <div className="flex items-center justify-between px-1">
+        <div className="text-[11px] uppercase tracking-wider font-bold text-text-muted">
+          {ordered.length} {ordered.length === 1 ? "session" : "sessions"} logged
+        </div>
+        {AUTH_ENABLED && (
+          <SyncControl state={syncState} onSync={handleSyncNow} />
+        )}
       </div>
       {ordered.map((s) => (
         <SessionCard key={s.id} session={s} allSessions={sessions} />
       ))}
     </div>
   );
+}
+
+function SyncControl({
+  state,
+  onSync,
+}: {
+  state: SyncState;
+  onSync: () => void;
+}) {
+  const label = state.inFlight
+    ? "Syncing…"
+    : state.lastError
+      ? "Sync error"
+      : state.lastSyncAt > 0
+        ? `Synced ${formatRelative(state.lastSyncAt)}`
+        : "Sync now";
+  const color = state.lastError
+    ? "#ef4444"
+    : state.inFlight
+      ? "#f59e0b"
+      : state.lastSyncAt > 0
+        ? "#10b981"
+        : "var(--color-text-dim)";
+  return (
+    <button
+      onClick={onSync}
+      disabled={state.inFlight}
+      className="text-[11px] font-semibold rounded-md px-2 py-1 cursor-pointer disabled:cursor-default"
+      style={{
+        background: "var(--color-card)",
+        border: "1px solid var(--color-border)",
+        color,
+      }}
+      title={state.lastError ?? label}
+    >
+      {label}
+    </button>
+  );
+}
+
+function formatRelative(ms: number): string {
+  const dt = Date.now() - ms;
+  const min = Math.floor(dt / 60000);
+  if (min < 1) return "just now";
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  return `${Math.floor(hr / 24)}d ago`;
 }
 
 interface SessionCardProps {

--- a/components/workout-view.tsx
+++ b/components/workout-view.tsx
@@ -55,9 +55,15 @@ const SetTracker = dynamic(() => import("@/components/set-tracker"), {
   ssr: false,
 });
 
-// Conditionally import AuthButton only when feature flag is on
+// Conditionally import AuthButton when either auth or AI feature flag is on.
+// FEATURE_AUTH gates login + cloud sync independently of AI suggestions; the
+// older FEATURE_AI_SUGGESTIONS flag is kept for backward compat (AI requires
+// auth, so turning AI on must also surface the button).
+const AUTH_ENABLED =
+  process.env.NEXT_PUBLIC_FEATURE_AUTH === "true" ||
+  process.env.NEXT_PUBLIC_FEATURE_AI_SUGGESTIONS === "true";
 const AuthButton =
-  process.env.NEXT_PUBLIC_FEATURE_AI_SUGGESTIONS === "true"
+  AUTH_ENABLED
     ? React.lazy(() => import("@/components/auth-button"))
     : null;
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -200,6 +200,36 @@ CREATE TABLE IF NOT EXISTS equipment (
   category  TEXT NOT NULL            -- "weights" | "machines" | "functional" | ...
 );
 
+-- ---- workout sessions (per-user logged workout history) ------------------
+--
+-- One row per finished WorkoutSession (lib/workout-log.ts). Active /
+-- in-progress sessions stay client-side until endSession() runs, then push.
+-- Conflict policy: last-write-wins per session id, by `updated_at`.
+--
+-- Modelling: the full WorkoutSession (including LoggedExercise[] / LoggedSet[])
+-- lives in `data` JSONB. We never query "all sets above 200lbs across users"
+-- — the only query is "give me this user's history" — so denormalising into
+-- session/exercise/set tables would add three joins for zero benefit and
+-- destroy ordering invariants. The hot scalars (`workout_key`, `started_at`,
+-- `ended_at`) are mirrored as columns so the history index doesn't have to
+-- crack the JSONB on every read.
+--
+-- equipment_photos are intentionally OUT — base64 dataURLs would balloon
+-- the JSONB. They stay localStorage-only until we add object storage.
+CREATE TABLE IF NOT EXISTS workout_sessions (
+  id           TEXT PRIMARY KEY,        -- session.id from client (s-<base36>-<rand>)
+  user_id      TEXT NOT NULL,           -- session.user.email
+  workout_key  TEXT NOT NULL,           -- "Push A", "Legs B", "Freestyle", ...
+  started_at   BIGINT NOT NULL,         -- epoch ms (matches client shape)
+  ended_at     BIGINT,                  -- epoch ms; null only for resync edge cases
+  data         JSONB NOT NULL,          -- full WorkoutSession blob
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS workout_sessions_user_started_idx
+  ON workout_sessions (user_id, started_at DESC);
+
 -- ---- updated_at trigger ---------------------------------------------------
 
 CREATE OR REPLACE FUNCTION set_updated_at()
@@ -213,6 +243,7 @@ $$ LANGUAGE plpgsql;
 DROP TRIGGER IF EXISTS exercises_updated_at        ON exercises;
 DROP TRIGGER IF EXISTS machine_variants_updated_at ON machine_variants;
 DROP TRIGGER IF EXISTS workouts_updated_at         ON workouts;
+DROP TRIGGER IF EXISTS workout_sessions_updated_at ON workout_sessions;
 
 CREATE TRIGGER exercises_updated_at
   BEFORE UPDATE ON exercises
@@ -224,4 +255,8 @@ CREATE TRIGGER machine_variants_updated_at
 
 CREATE TRIGGER workouts_updated_at
   BEFORE UPDATE ON workouts
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER workout_sessions_updated_at
+  BEFORE UPDATE ON workout_sessions
   FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/lib/workout-log.ts
+++ b/lib/workout-log.ts
@@ -124,6 +124,16 @@ export function endSession(active: WorkoutSession): {
   const sessions = [...loadSessions(), ended];
   saveSessions(sessions);
   saveActiveSession(null);
+  // Fire-and-forget cloud sync. No-ops gracefully when not signed in.
+  // Imported lazily to avoid a circular dep (workout-sync ← workout-log).
+  if (typeof window !== "undefined") {
+    import("./workout-sync")
+      .then((m) => m.pushSession(ended))
+      .catch(() => {
+        // Sync errors are surfaced via SyncState; localStorage write already
+        // succeeded, so the user's data is safe regardless.
+      });
+  }
   return { ended, sessions };
 }
 

--- a/lib/workout-sync.ts
+++ b/lib/workout-sync.ts
@@ -1,0 +1,193 @@
+// Cloud-sync orchestration for workout history.
+//
+// The local source of truth is `localStorage["workout-log:sessions"]` (see
+// lib/workout-log.ts). On login + on endSession + on manual "Sync now",
+// we run a pull-then-merge-then-push cycle:
+//
+//   1. GET  /api/workout-sessions[?since=<lastSyncAt>]  → remote rows
+//   2. Merge remote ∪ local by session id, picking the entry with the
+//      higher client wall-time watermark (endedAt | max set completedAt
+//      | startedAt). This is the same watermark the API uses for LWW, so
+//      both sides converge.
+//   3. PUT remote-newer rows back into localStorage; PUT local-newer rows
+//      to the server.
+//
+// Active in-progress sessions ("workout-log:active") are NOT synced — they
+// stay local until endSession() promotes them to the sessions array.
+
+import { loadState, saveState } from "./storage";
+import {
+  loadSessions,
+  saveSessions,
+  type WorkoutSession,
+} from "./workout-log";
+
+const SYNC_STATE_KEY = "nwb_sync_state";
+
+export interface SyncState {
+  /** Epoch ms of the last successful sync. 0 if never synced. */
+  lastSyncAt: number;
+  /** Last error message, or null if last attempt succeeded. */
+  lastError: string | null;
+  /** True while a sync is in flight. */
+  inFlight: boolean;
+}
+
+const DEFAULT_STATE: SyncState = {
+  lastSyncAt: 0,
+  lastError: null,
+  inFlight: false,
+};
+
+export function loadSyncState(): SyncState {
+  return loadState<SyncState>(SYNC_STATE_KEY, DEFAULT_STATE);
+}
+
+function setSyncState(patch: Partial<SyncState>): SyncState {
+  const next = { ...loadSyncState(), ...patch };
+  saveState(SYNC_STATE_KEY, next);
+  return next;
+}
+
+/** Client-side LWW watermark — must match the server's `clientWatermark`. */
+export function watermarkFor(ws: WorkoutSession): number {
+  const setMax = ws.exercises
+    .flatMap((e) => e.sets)
+    .reduce((acc, s) => Math.max(acc, s.completedAt), 0);
+  return Math.max(ws.endedAt ?? 0, setMax, ws.startedAt);
+}
+
+interface MergeResult {
+  /** Sessions to write to localStorage (winners by id). */
+  merged: WorkoutSession[];
+  /** Sessions whose local copy is newer — push these to the server. */
+  toPush: WorkoutSession[];
+}
+
+export function mergeSessions(
+  local: WorkoutSession[],
+  remote: WorkoutSession[],
+): MergeResult {
+  const byId = new Map<string, { ws: WorkoutSession; source: "local" | "remote" }>();
+  for (const ws of remote) byId.set(ws.id, { ws, source: "remote" });
+  for (const ws of local) {
+    const existing = byId.get(ws.id);
+    if (!existing) {
+      byId.set(ws.id, { ws, source: "local" });
+      continue;
+    }
+    if (watermarkFor(ws) > watermarkFor(existing.ws)) {
+      byId.set(ws.id, { ws, source: "local" });
+    }
+  }
+
+  const merged = Array.from(byId.values()).map((e) => e.ws);
+  // Stable sort by startedAt asc to match the existing local order.
+  merged.sort((a, b) => a.startedAt - b.startedAt);
+
+  // Push: anything whose winning copy came from local.
+  const toPush = Array.from(byId.values())
+    .filter((e) => e.source === "local")
+    .map((e) => e.ws);
+
+  return { merged, toPush };
+}
+
+export interface SyncOutcome {
+  pulled: number;
+  pushed: number;
+  skipped: number;
+  error?: string;
+}
+
+/**
+ * Run a full sync cycle. Returns counts for diagnostics. Safe to call
+ * repeatedly; if a sync is already in flight, the second call is a no-op
+ * and returns the in-flight error placeholder.
+ */
+export async function syncWorkoutSessions(): Promise<SyncOutcome> {
+  const state = loadSyncState();
+  if (state.inFlight) {
+    return { pulled: 0, pushed: 0, skipped: 0, error: "in_flight" };
+  }
+  setSyncState({ inFlight: true, lastError: null });
+
+  try {
+    // 1. Pull
+    const pullRes = await fetch("/api/workout-sessions", {
+      method: "GET",
+      credentials: "same-origin",
+    });
+    if (pullRes.status === 401) {
+      throw new Error("Not signed in");
+    }
+    if (!pullRes.ok) {
+      throw new Error(`Pull failed: ${pullRes.status}`);
+    }
+    const pullJson = (await pullRes.json()) as { sessions: WorkoutSession[] };
+    const remote = pullJson.sessions ?? [];
+
+    // 2. Merge
+    const local = loadSessions();
+    const { merged, toPush } = mergeSessions(local, remote);
+    saveSessions(merged);
+
+    // 3. Push (only the local winners)
+    let pushed = 0;
+    let skipped = 0;
+    if (toPush.length > 0) {
+      const pushRes = await fetch("/api/workout-sessions", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        credentials: "same-origin",
+        body: JSON.stringify({ sessions: toPush }),
+      });
+      if (!pushRes.ok) {
+        throw new Error(`Push failed: ${pushRes.status}`);
+      }
+      const pushJson = (await pushRes.json()) as {
+        upserted: number;
+        skipped: number;
+      };
+      pushed = pushJson.upserted;
+      skipped = pushJson.skipped;
+    }
+
+    setSyncState({
+      inFlight: false,
+      lastError: null,
+      lastSyncAt: Date.now(),
+    });
+
+    return { pulled: remote.length, pushed, skipped };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    setSyncState({ inFlight: false, lastError: msg });
+    return { pulled: 0, pushed: 0, skipped: 0, error: msg };
+  }
+}
+
+/**
+ * Push a single session immediately (used by endSession). Doesn't pull —
+ * for that, call syncWorkoutSessions() instead. Quietly no-ops if the user
+ * isn't signed in.
+ */
+export async function pushSession(ws: WorkoutSession): Promise<void> {
+  try {
+    const res = await fetch("/api/workout-sessions", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      credentials: "same-origin",
+      body: JSON.stringify({ sessions: [ws] }),
+    });
+    if (res.status === 401) return; // not signed in; localStorage already has it
+    if (!res.ok) {
+      setSyncState({ lastError: `Push failed: ${res.status}` });
+      return;
+    }
+    setSyncState({ lastSyncAt: Date.now(), lastError: null });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    setSyncState({ lastError: msg });
+  }
+}


### PR DESCRIPTION
## Summary

Real path for login: per-user workout history persistence in Postgres (Neon) with last-write-wins conflict resolution, plus a new feature flag `NEXT_PUBLIC_FEATURE_AUTH` that gates the Sign-in button **independently of AI suggestions**. Resolves the "login but nothing actually persists" gap.

## Schema

`workout_sessions` table — `id` PK, `user_id` (email), `workout_key`, `started_at`/`ended_at` BIGINT epoch ms, `data` JSONB (full `WorkoutSession` blob), `created_at`/`updated_at` TIMESTAMPTZ. Index on `(user_id, started_at DESC)`.

JSONB the whole session rather than normalize — we never query individual sets across users. `equipment_photos` intentionally excluded (base64 blobs would balloon the column; deferred until object storage).

## Sync model

- **Last-write-wins per session id** by client wall-time watermark = `max(endedAt, max(set.completedAt), startedAt)`. The API enforces it in the UPSERT WHERE clause; the client uses the same formula in `mergeSessions()` so both sides converge.
- **Triggers:** (a) `endSession()` fires single-session push, (b) login fires full pull → merge → push, (c) "Sync now" button in History tab.
- **Active in-progress sessions stay local-only** until `endSession()` promotes them.
- **Cross-device note:** later device's snapshot wins wholesale per session id. No automatic merge of conflicting sets within a session.

## Files

- `db/schema.sql` — new `workout_sessions` table + trigger
- `app/api/workout-sessions/route.ts` — GET/PUT/DELETE, auth-gated
- `lib/workout-sync.ts` — `syncWorkoutSessions()`, `pushSession()`, `mergeSessions()`, sync state
- `lib/workout-log.ts` — `endSession()` lazy-imports + fires `pushSession`
- `components/auth-button.tsx` — initial sync on auth + status dot over avatar
- `components/history-view.tsx` — "Sync now" button + relative time
- `components/workout-view.tsx` — AuthButton lights up when either `FEATURE_AUTH` or `FEATURE_AI_SUGGESTIONS` is on
- `.env.local.example` — new `NEXT_PUBLIC_FEATURE_AUTH=false` default

## ⚠️ Pre-merge checklist (DO NOT MERGE until these are done)

- [ ] **Google OAuth client** (you, console.cloud.google.com)
  - OAuth consent screen: External, app name, your email, scopes `openid email profile`, add yourself as test user
  - Credentials → OAuth client ID → Web application
  - Authorized JavaScript origin: `https://nfit.93.fyi`
  - Authorized redirect URI: `https://nfit.93.fyi/api/auth/callback/google` ← exact string, NextAuth v5 path
- [ ] **Vercel env vars** (you, vercel.com → nwb-plan → Settings → Environment Variables, Production):
  - `GOOGLE_CLIENT_ID` = (from above)
  - `GOOGLE_CLIENT_SECRET` = (from above)
  - `NEXTAUTH_SECRET` = `openssl rand -base64 32`
  - `NEXTAUTH_URL` = `https://nfit.93.fyi`
  - **Do not** set `NEXT_PUBLIC_FEATURE_AUTH=true` yet — flip after migration
- [ ] **Apply DB migration** to prod Neon (me): `vercel env pull .env.local && psql "$POSTGRES_URL" -f db/schema.sql`. The schema is idempotent (`IF NOT EXISTS`), safe to re-run.

## Post-merge

- [ ] Set `NEXT_PUBLIC_FEATURE_AUTH=true` in Vercel Production env → Vercel auto-redeploys → Sign-in button appears in the header

## Test plan

- [x] `npm run build` exits 0; `/api/workout-sessions` registered as a server route
- [ ] Local: `vercel env pull` + apply schema + `npm run dev` + sign in with Google → sync state goes green, end a workout → row appears in `workout_sessions`
- [ ] Cross-device: log a session on phone, sign in on desktop, "Sync now" → session appears
- [ ] Conflict: end same session id from two devices with different sets → later watermark wins (use a clock skew check)

https://claude.ai/code/session_014ptfgmc5zrrywY9hBy58Zn

---
_Generated by [Claude Code](https://claude.ai/code/session_014ptfgmc5zrrywY9hBy58Zn)_