### PR TITLE
feat: ad-hoc supersets — universal search + free-text complement

### DIFF
--- a/components/complement-picker.tsx
+++ b/components/complement-picker.tsx
@@ -94,6 +94,184 @@ export function decodeComplement(id: ComplementId): {
   return { kind: "supp", value: rest.join(sep) };
 }
 
+// ── Search helpers ───────────────────────────────────────────────────────
+
+export type ComplementSource =
+  | "catalog"
+  | "nearby"
+  | "supp"
+  | "core"
+  | "mobility"
+  | "pt";
+
+export interface SearchResult {
+  id: ComplementId;
+  source: ComplementSource;
+  /** Short uppercase label shown on the chip (NEARBY / CATALOG / etc.). */
+  label: string;
+  /** Source accent color (matches existing color scheme). */
+  color: string;
+  /** Display title — exercise name or supplement name. */
+  title: string;
+  /** "3×10" or similar; empty string if not applicable. */
+  sets: string;
+  /** First line of execution / instruction. */
+  description: string;
+}
+
+interface SearchInputs {
+  nearbyAvail: NearbySuperset[];
+  suppAvail: Array<{ name: string; data: (typeof SUPPLEMENT_EX)[string] }>;
+  coreAvail: Array<{
+    name: string;
+    region: string;
+    data: (typeof SUPPLEMENT_EX)[string];
+  }>;
+  ptAvail: Array<{ id: string; name: string; sets: string; execution: string }>;
+  mobilityAvail: MobilitySupplement[];
+  /** All exercise display-names from EX (only searched when query is non-empty). */
+  catalogNames: string[];
+  /** EX lookup so we can build sets/description for catalog hits. */
+  catalogLookup: Record<string, { name: string; sets: [string, string][]; execution?: string }>;
+}
+
+const SOURCE_META: Record<ComplementSource, { label: string; color: string }> = {
+  catalog: { label: "CATALOG", color: "#3b82f6" },
+  nearby: { label: "NEARBY", color: "#14b8a6" },
+  supp: { label: "L-LEG", color: "#14b8a6" },
+  core: { label: "CORE", color: "#f97316" },
+  mobility: { label: "MOBILITY", color: "#0ea5e9" },
+  pt: { label: "PT", color: "#34d399" },
+};
+
+export function searchComplements(
+  query: string,
+  filters: Set<ComplementSource>,
+  inputs: SearchInputs,
+): SearchResult[] {
+  const q = query.trim().toLowerCase();
+  const results: SearchResult[] = [];
+
+  const want = (s: ComplementSource) => filters.size === 0 || filters.has(s);
+
+  if (want("nearby")) {
+    for (const ns of inputs.nearbyAvail) {
+      results.push({
+        id: encodeNearbyId(ns),
+        source: "nearby",
+        label: SOURCE_META.nearby.label,
+        color: SOURCE_META.nearby.color,
+        title: ns.title,
+        sets: ns.sets,
+        description: ns.instruction,
+      });
+    }
+  }
+
+  if (want("supp")) {
+    for (const { name, data } of inputs.suppAvail) {
+      const s = data.sets[0];
+      results.push({
+        id: encodeSuppId(name),
+        source: "supp",
+        label: SOURCE_META.supp.label,
+        color: SOURCE_META.supp.color,
+        title: name,
+        sets: `${s[0]}×${s[1]}`,
+        description: data.execution,
+      });
+    }
+  }
+
+  if (want("core")) {
+    for (const { name, region, data } of inputs.coreAvail) {
+      const s = data.sets[0];
+      results.push({
+        id: encodeCoreId(name),
+        source: "core",
+        label: region.toUpperCase(),
+        color: SOURCE_META.core.color,
+        title: name,
+        sets: `${s[0]}×${s[1]}`,
+        description: data.execution,
+      });
+    }
+  }
+
+  if (want("pt")) {
+    for (const ex of inputs.ptAvail) {
+      results.push({
+        id: encodePTId(ex.id),
+        source: "pt",
+        label: SOURCE_META.pt.label,
+        color: SOURCE_META.pt.color,
+        title: ex.name,
+        sets: ex.sets,
+        description: ex.execution,
+      });
+    }
+  }
+
+  if (want("mobility")) {
+    for (const m of inputs.mobilityAvail) {
+      const color =
+        m.kind === "breathing"
+          ? "#8b5cf6"
+          : m.kind === "stretch"
+            ? "#f59e0b"
+            : SOURCE_META.mobility.color;
+      const label =
+        m.kind === "breathing"
+          ? "BREATH"
+          : m.kind === "stretch"
+            ? "STRETCH"
+            : SOURCE_META.mobility.label;
+      results.push({
+        id: encodeMobilityId(m),
+        source: "mobility",
+        label,
+        color,
+        title: m.name,
+        sets: m.sets,
+        description: m.instruction,
+      });
+    }
+  }
+
+  // Catalog only surfaces when the user has typed something, OR when the
+  // catalog filter is the only one active (so they explicitly opted into
+  // browsing the full catalog without a query).
+  const catalogOnly = filters.size === 1 && filters.has("catalog");
+  if (want("catalog") && (q.length > 0 || catalogOnly)) {
+    for (const name of inputs.catalogNames) {
+      const data = inputs.catalogLookup[name];
+      if (!data) continue;
+      const s = data.sets[0];
+      results.push({
+        id: encodeLibId(name),
+        source: "catalog",
+        label: SOURCE_META.catalog.label,
+        color: SOURCE_META.catalog.color,
+        title: name,
+        sets: s ? `${s[0]}×${s[1]}` : "",
+        description: data.execution ?? "",
+      });
+    }
+  }
+
+  if (q.length === 0) return results;
+
+  // Substring match on title; exact-prefix matches sort before substring matches.
+  const filtered = results.filter((r) => r.title.toLowerCase().includes(q));
+  filtered.sort((a, b) => {
+    const aPrefix = a.title.toLowerCase().startsWith(q) ? 0 : 1;
+    const bPrefix = b.title.toLowerCase().startsWith(q) ? 0 : 1;
+    if (aPrefix !== bPrefix) return aPrefix - bPrefix;
+    return a.title.localeCompare(b.title);
+  });
+  return filtered;
+}
+
 // ── Shared button for all complement types ──────────────────────────────
 
 interface ComplementButtonProps {

--- a/components/complement-picker.tsx
+++ b/components/complement-picker.tsx
@@ -19,7 +19,7 @@ import { loadState } from "@/lib/storage";
 import { cssAlpha } from "@/lib/css-utils";
 
 /**
- * A complement the user can add to an exercise. There are five kinds:
+ * A complement the user can add to an exercise. There are seven kinds:
  *  - "nearby"   — one of NEARBY_SUPERSETS (needs nearby equipment)
  *  - "supp"     — a left-leg supplement (looked up in SUPPLEMENT_EX by name)
  *  - "core"     — a core drill from SUPPLEMENT_CORE for the current workout day
@@ -28,6 +28,8 @@ import { cssAlpha } from "@/lib/css-utils";
  *  - "mobility" — a zero-equipment mobility / stretch / breathing drill
  *  - "pt"       — a phase-gated PT exercise from PT_EXERCISES (left-leg
  *                 conditioning surface; filtered by current nwb_pt_phase)
+ *  - "lib"      — any catalog exercise looked up in EX by display name
+ *  - "text"     — free-form user text (base64-encoded payload)
  */
 export type ComplementId = string;
 

--- a/components/complement-picker.tsx
+++ b/components/complement-picker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import {
   NEARBY_SUPERSETS,
   SUPPLEMENT_LEFT_LEG,
@@ -438,9 +438,6 @@ export default function ComplementPicker({
       }),
     [query, filters, nearbyAvail, suppAvail, coreAvail, ptAvail, mobilityAvail, catalogNames, catalogLookup],
   );
-
-  // useEffect reserved for Task 7 (custom-text mode)
-  void useEffect;
 
   return (
     <div

--- a/components/complement-picker.tsx
+++ b/components/complement-picker.tsx
@@ -55,8 +55,7 @@ export function encodeLibId(exerciseName: string): ComplementId {
 
 export function encodeTextId(text: string): ComplementId {
   // base64 keeps the SEP delimiter safe even if the user types pipes
-  if (typeof btoa === "function") return `text${SEP}${btoa(text)}`;
-  return `text${SEP}${Buffer.from(text, "utf-8").toString("base64")}`;
+  return `text${SEP}${btoa(text)}`;
 }
 
 export function decodeComplement(id: ComplementId): {
@@ -86,10 +85,7 @@ export function decodeComplement(id: ComplementId): {
     const encoded = rest.join(sep);
     let decoded = encoded;
     try {
-      decoded =
-        typeof atob === "function"
-          ? atob(encoded)
-          : Buffer.from(encoded, "base64").toString("utf-8");
+      decoded = atob(encoded);
     } catch {
       decoded = encoded;
     }

--- a/components/complement-picker.tsx
+++ b/components/complement-picker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   NEARBY_SUPERSETS,
   SUPPLEMENT_LEFT_LEG,
@@ -17,6 +17,7 @@ import {
 } from "@/lib/pt-exercises";
 import { loadState } from "@/lib/storage";
 import { cssAlpha } from "@/lib/css-utils";
+import { EX } from "@/lib/exercises";
 
 /**
  * A complement the user can add to an exercise. There are seven kinds:
@@ -413,12 +414,33 @@ export default function ComplementPicker({
     return { nearbyAvail, suppAvail, ptAvail, coreAvail, coreSubtitle, mobilityAvail };
   }, [exerciseRequires, exerciseCategory, workoutKey, nearbySelections, ptPhase]);
 
-  const hasAny =
-    nearbyAvail.length > 0 ||
-    suppAvail.length > 0 ||
-    ptAvail.length > 0 ||
-    coreAvail.length > 0 ||
-    mobilityAvail.length > 0;
+  const catalogNames = useMemo(() => Object.keys(EX), []);
+  const catalogLookup = useMemo(() => EX as unknown as SearchInputs["catalogLookup"], []);
+
+  const [query, setQuery] = useState("");
+  const [filters, setFilters] = useState<Set<ComplementSource>>(() => new Set());
+
+  const results = useMemo(
+    () =>
+      searchComplements(query, filters, {
+        nearbyAvail,
+        suppAvail,
+        coreAvail,
+        ptAvail: ptAvail.map((p) => ({
+          id: p.id,
+          name: p.name,
+          sets: p.sets,
+          execution: p.execution,
+        })),
+        mobilityAvail,
+        catalogNames,
+        catalogLookup,
+      }),
+    [query, filters, nearbyAvail, suppAvail, coreAvail, ptAvail, mobilityAvail, catalogNames, catalogLookup],
+  );
+
+  // useEffect reserved for Task 7 (custom-text mode)
+  void useEffect;
 
   return (
     <div
@@ -471,164 +493,43 @@ export default function ComplementPicker({
 
         {/* Body */}
         <div className="overflow-y-auto flex-1 px-4 pb-6 pt-3">
-          {!hasAny && (
+          <input
+            data-testid="complement-search"
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search complements..."
+            className="w-full mb-3 px-3 py-2 rounded-lg text-sm font-[inherit]"
+            style={{
+              background: "var(--color-bg)",
+              border: "1px solid var(--color-border)",
+              color: "var(--color-text)",
+            }}
+          />
+
+          {results.length === 0 && (
             <div className="text-[12px] text-text-muted py-3 leading-relaxed">
-              Nothing in reach right now. Open the edit sheet and select nearby
-              equipment, or try adding generic quad sets below.
+              {query
+                ? `No matches for "${query}".`
+                : "Nothing in reach right now. Open the edit sheet and select nearby equipment, or try adding generic quad sets below."}
             </div>
           )}
 
-          {coreAvail.length > 0 && (
-            <>
-              <div className="text-[10px] font-bold text-text-muted uppercase tracking-wider mb-2">
-                Core ({coreAvail.length})
+          <div className="space-y-1.5">
+            {results.map((r) => (
+              <div data-testid="complement-result" key={r.id}>
+                <ComplementButton
+                  label={r.label}
+                  color={r.color}
+                  title={r.title}
+                  sets={r.sets}
+                  description={r.description}
+                  active={activeSet.has(r.id)}
+                  onClick={() => onToggle(r.id)}
+                />
               </div>
-              {coreSubtitle && (
-                <div className="text-[10px] text-text-muted mb-2 leading-snug">
-                  {coreSubtitle} &mdash; day-specific core routine for{" "}
-                  {workoutKey}.
-                </div>
-              )}
-              <div className="space-y-1.5 mb-4">
-                {coreAvail.map(({ name, region, data }) => {
-                  const id = encodeCoreId(name);
-                  const sets = data.sets[0];
-                  return (
-                    <ComplementButton
-                      key={id}
-                      label={region.toUpperCase()}
-                      color="#f97316"
-                      title={name}
-                      sets={`${sets[0]}\u00D7${sets[1]}`}
-                      description={data.execution}
-                      active={activeSet.has(id)}
-                      onClick={() => onToggle(id)}
-                    />
-                  );
-                })}
-              </div>
-            </>
-          )}
-
-          {nearbyAvail.length > 0 && (
-            <>
-              <div className="text-[10px] font-bold text-text-muted uppercase tracking-wider mb-2">
-                In reach ({nearbyAvail.length})
-              </div>
-              <div className="space-y-1.5 mb-4">
-                {nearbyAvail.map((ns) => {
-                  const id = encodeNearbyId(ns);
-                  return (
-                    <ComplementButton
-                      key={id}
-                      label="NEARBY"
-                      color="#14b8a6"
-                      title={ns.title}
-                      sets={ns.sets}
-                      description={ns.instruction}
-                      active={activeSet.has(id)}
-                      onClick={() => onToggle(id)}
-                    />
-                  );
-                })}
-              </div>
-            </>
-          )}
-
-          {suppAvail.length > 0 && (
-            <>
-              <div className="text-[10px] font-bold text-text-muted uppercase tracking-wider mb-2">
-                Left-leg rehab ({suppAvail.length})
-              </div>
-              <div className="space-y-1.5 mb-4">
-                {suppAvail.map(({ name, data }) => {
-                  const id = encodeSuppId(name);
-                  const sets = data.sets[0];
-                  return (
-                    <ComplementButton
-                      key={id}
-                      label="L-LEG"
-                      color="#14b8a6"
-                      title={name}
-                      sets={`${sets[0]}\u00D7${sets[1]}`}
-                      description={data.execution}
-                      active={activeSet.has(id)}
-                      onClick={() => onToggle(id)}
-                    />
-                  );
-                })}
-              </div>
-            </>
-          )}
-
-          {ptAvail.length > 0 && (
-            <>
-              <div className="text-[10px] font-bold text-text-muted uppercase tracking-wider mb-2">
-                PT \u2014 Left-leg conditioning ({ptAvail.length})
-              </div>
-              <div className="text-[10px] text-text-muted mb-2 leading-snug">
-                Phase: <strong>{ptPhase}</strong> &mdash; phase-gated PT
-                progression. Switch phase from the Rehab tab.
-              </div>
-              <div className="space-y-1.5 mb-4">
-                {ptAvail.map((ex) => {
-                  const id = encodePTId(ex.id);
-                  return (
-                    <ComplementButton
-                      key={id}
-                      label="PT"
-                      color="#34d399"
-                      title={ex.name}
-                      sets={ex.sets}
-                      description={ex.execution}
-                      active={activeSet.has(id)}
-                      onClick={() => onToggle(id)}
-                    />
-                  );
-                })}
-              </div>
-            </>
-          )}
-
-          {mobilityAvail.length > 0 && (
-            <>
-              <div className="text-[10px] font-bold text-text-muted uppercase tracking-wider mb-2">
-                Mobility &amp; stretches ({mobilityAvail.length})
-              </div>
-              <div className="text-[10px] text-text-muted mb-2 leading-snug">
-                Zero equipment — do these right on the machine you&rsquo;re using.
-              </div>
-              <div className="space-y-1.5">
-                {mobilityAvail.map((m) => {
-                  const id = encodeMobilityId(m);
-                  const color =
-                    m.kind === "breathing"
-                      ? "#8b5cf6"
-                      : m.kind === "stretch"
-                        ? "#f59e0b"
-                        : "#0ea5e9";
-                  const label =
-                    m.kind === "breathing"
-                      ? "BREATH"
-                      : m.kind === "stretch"
-                        ? "STRETCH"
-                        : "MOBILITY";
-                  return (
-                    <ComplementButton
-                      key={id}
-                      label={label}
-                      color={color}
-                      title={m.name}
-                      sets={m.sets}
-                      description={m.instruction}
-                      active={activeSet.has(id)}
-                      onClick={() => onToggle(id)}
-                    />
-                  );
-                })}
-              </div>
-            </>
-          )}
+            ))}
+          </div>
         </div>
 
         {/* Footer */}

--- a/components/complement-picker.tsx
+++ b/components/complement-picker.tsx
@@ -49,8 +49,18 @@ export function encodePTId(ptId: string): ComplementId {
   return `pt${SEP}${ptId}`;
 }
 
+export function encodeLibId(exerciseName: string): ComplementId {
+  return `lib${SEP}${exerciseName}`;
+}
+
+export function encodeTextId(text: string): ComplementId {
+  // base64 keeps the SEP delimiter safe even if the user types pipes
+  if (typeof btoa === "function") return `text${SEP}${btoa(text)}`;
+  return `text${SEP}${Buffer.from(text, "utf-8").toString("base64")}`;
+}
+
 export function decodeComplement(id: ComplementId): {
-  kind: "nearby" | "supp" | "core" | "mobility" | "pt";
+  kind: "nearby" | "supp" | "core" | "mobility" | "pt" | "lib" | "text";
   value: string;
   sub?: string;
 } {
@@ -68,6 +78,22 @@ export function decodeComplement(id: ComplementId): {
   }
   if (kind === "pt") {
     return { kind: "pt", value: rest.join(sep) };
+  }
+  if (kind === "lib") {
+    return { kind: "lib", value: rest.join(sep) };
+  }
+  if (kind === "text") {
+    const encoded = rest.join(sep);
+    let decoded = encoded;
+    try {
+      decoded =
+        typeof atob === "function"
+          ? atob(encoded)
+          : Buffer.from(encoded, "base64").toString("utf-8");
+    } catch {
+      decoded = encoded;
+    }
+    return { kind: "text", value: decoded };
   }
   return { kind: "supp", value: rest.join(sep) };
 }

--- a/components/complement-picker.tsx
+++ b/components/complement-picker.tsx
@@ -419,6 +419,8 @@ export default function ComplementPicker({
 
   const [query, setQuery] = useState("");
   const [filters, setFilters] = useState<Set<ComplementSource>>(() => new Set());
+  const [customMode, setCustomMode] = useState(false);
+  const [customText, setCustomText] = useState("");
 
   const results = useMemo(
     () =>
@@ -490,83 +492,150 @@ export default function ComplementPicker({
 
         {/* Body */}
         <div className="overflow-y-auto flex-1 px-4 pb-6 pt-3">
-          <input
-            data-testid="complement-search"
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search complements..."
-            className="w-full mb-3 px-3 py-2 rounded-lg text-sm font-[inherit]"
-            style={{
-              background: "var(--color-bg)",
-              border: "1px solid var(--color-border)",
-              color: "var(--color-text)",
-            }}
-          />
+          {!customMode && (
+            <>
+              <input
+                data-testid="complement-search"
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search complements..."
+                className="w-full mb-3 px-3 py-2 rounded-lg text-sm font-[inherit]"
+                style={{
+                  background: "var(--color-bg)",
+                  border: "1px solid var(--color-border)",
+                  color: "var(--color-text)",
+                }}
+              />
 
-          <div className="flex flex-wrap gap-1.5 mb-3">
-            {([
-              ["all", "All"],
-              ["catalog", "Catalog"],
-              ["nearby", "Nearby"],
-              ["supp", "L-Leg"],
-              ["core", "Core"],
-              ["mobility", "Mobility"],
-              ["pt", "PT"],
-            ] as const).map(([key, label]) => {
-              const isAll = key === "all";
-              const active = isAll
-                ? filters.size === 0
-                : filters.has(key as ComplementSource);
-              return (
-                <button
-                  key={key}
-                  data-testid={`filter-chip-${key}`}
-                  onClick={() => {
-                    if (isAll) {
-                      setFilters(new Set());
-                    } else {
-                      setFilters(new Set([key as ComplementSource]));
-                    }
-                  }}
-                  className="text-[10px] font-bold uppercase tracking-wider rounded-full px-2.5 py-1 cursor-pointer font-[inherit]"
-                  style={{
-                    background: active
-                      ? "var(--color-accent)22"
-                      : "var(--color-bg)",
-                    border: `1px solid ${active ? "var(--color-accent)" : "var(--color-border)"}`,
-                    color: active ? "var(--color-accent)" : "var(--color-text-muted)",
-                  }}
-                >
-                  {label}
-                </button>
-              );
-            })}
-          </div>
+              <div className="flex flex-wrap gap-1.5 mb-3">
+                {([
+                  ["all", "All"],
+                  ["catalog", "Catalog"],
+                  ["nearby", "Nearby"],
+                  ["supp", "L-Leg"],
+                  ["core", "Core"],
+                  ["mobility", "Mobility"],
+                  ["pt", "PT"],
+                ] as const).map(([key, label]) => {
+                  const isAll = key === "all";
+                  const active = isAll
+                    ? filters.size === 0
+                    : filters.has(key as ComplementSource);
+                  return (
+                    <button
+                      key={key}
+                      data-testid={`filter-chip-${key}`}
+                      onClick={() => {
+                        if (isAll) {
+                          setFilters(new Set());
+                        } else {
+                          setFilters(new Set([key as ComplementSource]));
+                        }
+                      }}
+                      className="text-[10px] font-bold uppercase tracking-wider rounded-full px-2.5 py-1 cursor-pointer font-[inherit]"
+                      style={{
+                        background: active
+                          ? "var(--color-accent)22"
+                          : "var(--color-bg)",
+                        border: `1px solid ${active ? "var(--color-accent)" : "var(--color-border)"}`,
+                        color: active ? "var(--color-accent)" : "var(--color-text-muted)",
+                      }}
+                    >
+                      {label}
+                    </button>
+                  );
+                })}
+              </div>
 
-          {results.length === 0 && (
-            <div className="text-[12px] text-text-muted py-3 leading-relaxed">
-              {query
-                ? `No matches for "${query}".`
-                : "Nothing in reach right now. Open the edit sheet and select nearby equipment, or try adding generic quad sets below."}
-            </div>
+              <button
+                data-testid="custom-text-toggle"
+                onClick={() => setCustomMode(true)}
+                className="mb-3 text-[11px] font-bold rounded-full px-2.5 py-1 cursor-pointer font-[inherit]"
+                style={{
+                  background: "var(--color-bg)",
+                  border: "1px solid var(--color-border)",
+                  color: "var(--color-text-muted)",
+                }}
+              >
+                + Custom text
+              </button>
+
+              {results.length === 0 && (
+                <div className="text-[12px] text-text-muted py-3 leading-relaxed">
+                  {query
+                    ? `No matches for "${query}".`
+                    : "Nothing in reach right now. Open the edit sheet and select nearby equipment, or try adding generic quad sets below."}
+                </div>
+              )}
+
+              <div className="space-y-1.5">
+                {results.map((r) => (
+                  <div data-testid="complement-result" key={r.id}>
+                    <ComplementButton
+                      label={r.label}
+                      color={r.color}
+                      title={r.title}
+                      sets={r.sets}
+                      description={r.description}
+                      active={activeSet.has(r.id)}
+                      onClick={() => onToggle(r.id)}
+                    />
+                  </div>
+                ))}
+              </div>
+            </>
           )}
 
-          <div className="space-y-1.5">
-            {results.map((r) => (
-              <div data-testid="complement-result" key={r.id}>
-                <ComplementButton
-                  label={r.label}
-                  color={r.color}
-                  title={r.title}
-                  sets={r.sets}
-                  description={r.description}
-                  active={activeSet.has(r.id)}
-                  onClick={() => onToggle(r.id)}
+          {customMode && (
+            <div data-testid="custom-text-form">
+              <div className="flex gap-2 mb-3">
+                <input
+                  data-testid="custom-text-input"
+                  type="text"
+                  value={customText}
+                  onChange={(e) => setCustomText(e.target.value)}
+                  placeholder="Type your superset..."
+                  autoFocus
+                  className="flex-1 px-3 py-2 rounded-lg text-sm font-[inherit]"
+                  style={{
+                    background: "var(--color-bg)",
+                    border: "1px solid var(--color-border)",
+                    color: "var(--color-text)",
+                  }}
                 />
+                <button
+                  data-testid="custom-text-save"
+                  onClick={() => {
+                    const trimmed = customText.trim();
+                    if (!trimmed) return;
+                    onToggle(encodeTextId(trimmed));
+                    setCustomText("");
+                    setCustomMode(false);
+                    onClose();
+                  }}
+                  className="px-3 rounded-lg text-sm font-bold cursor-pointer font-[inherit]"
+                  style={{
+                    background: "var(--color-accent)22",
+                    border: "1px solid var(--color-accent)",
+                    color: "var(--color-accent)",
+                  }}
+                >
+                  Save
+                </button>
               </div>
-            ))}
-          </div>
+              <button
+                data-testid="custom-text-cancel"
+                onClick={() => {
+                  setCustomMode(false);
+                  setCustomText("");
+                }}
+                className="text-[11px] text-text-muted cursor-pointer font-[inherit]"
+              >
+                Cancel
+              </button>
+            </div>
+          )}
         </div>
 
         {/* Footer */}

--- a/components/complement-picker.tsx
+++ b/components/complement-picker.tsx
@@ -373,7 +373,7 @@ export default function ComplementPicker({
     [],
   );
 
-  const { nearbyAvail, suppAvail, ptAvail, coreAvail, coreSubtitle, mobilityAvail } = useMemo(() => {
+  const { nearbyAvail, suppAvail, ptAvail, coreAvail, mobilityAvail } = useMemo(() => {
     const inUseIds = new Set(
       exerciseRequires.map((r) => EQUIP_TO_NEARBY[r]).filter(Boolean),
     );
@@ -404,14 +404,13 @@ export default function ComplementPicker({
       region: string;
       data: (typeof SUPPLEMENT_EX)[string];
     }>;
-    const coreSubtitle = coreDay?.subtitle ?? "";
 
     const mobilityAvail = MOBILITY_SUPPLEMENTS.filter((m) =>
       m.appliesTo.includes("all") ||
       m.appliesTo.includes(exerciseCategory as "push" | "pull" | "legs" | "core" | "cardio"),
     );
 
-    return { nearbyAvail, suppAvail, ptAvail, coreAvail, coreSubtitle, mobilityAvail };
+    return { nearbyAvail, suppAvail, ptAvail, coreAvail, mobilityAvail };
   }, [exerciseRequires, exerciseCategory, workoutKey, nearbySelections, ptPhase]);
 
   const catalogNames = useMemo(() => Object.keys(EX), []);

--- a/components/complement-picker.tsx
+++ b/components/complement-picker.tsx
@@ -504,6 +504,46 @@ export default function ComplementPicker({
             }}
           />
 
+          <div className="flex flex-wrap gap-1.5 mb-3">
+            {([
+              ["all", "All"],
+              ["catalog", "Catalog"],
+              ["nearby", "Nearby"],
+              ["supp", "L-Leg"],
+              ["core", "Core"],
+              ["mobility", "Mobility"],
+              ["pt", "PT"],
+            ] as const).map(([key, label]) => {
+              const isAll = key === "all";
+              const active = isAll
+                ? filters.size === 0
+                : filters.has(key as ComplementSource);
+              return (
+                <button
+                  key={key}
+                  data-testid={`filter-chip-${key}`}
+                  onClick={() => {
+                    if (isAll) {
+                      setFilters(new Set());
+                    } else {
+                      setFilters(new Set([key as ComplementSource]));
+                    }
+                  }}
+                  className="text-[10px] font-bold uppercase tracking-wider rounded-full px-2.5 py-1 cursor-pointer font-[inherit]"
+                  style={{
+                    background: active
+                      ? "var(--color-accent)22"
+                      : "var(--color-bg)",
+                    border: `1px solid ${active ? "var(--color-accent)" : "var(--color-border)"}`,
+                    color: active ? "var(--color-accent)" : "var(--color-text-muted)",
+                  }}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+
           {results.length === 0 && (
             <div className="text-[12px] text-text-muted py-3 leading-relaxed">
               {query

--- a/components/workout-view.tsx
+++ b/components/workout-view.tsx
@@ -1097,6 +1097,18 @@ export default function WorkoutView() {
             removable: true,
             complementId: id,
           });
+        } else if (decoded.kind === "text") {
+          cards.push({
+            key: id,
+            kind: "leftleg",
+            label: "CUSTOM",
+            color: "#71717a",
+            title: decoded.value,
+            sets: "",
+            instruction: "",
+            removable: true,
+            complementId: id,
+          });
         }
       }
 
@@ -1401,6 +1413,14 @@ export default function WorkoutView() {
                   name: decoded.value,
                   sets: s ? `${s[0]}×${s[1]}` : "",
                   instruction: data.execution ?? "",
+                  safety: "",
+                });
+              } else if (decoded.kind === "text") {
+                supps.push({
+                  type: "leftleg",
+                  name: decoded.value,
+                  sets: "",
+                  instruction: "",
                   safety: "",
                 });
               }

--- a/components/workout-view.tsx
+++ b/components/workout-view.tsx
@@ -1082,6 +1082,21 @@ export default function WorkoutView() {
             removable: true,
             complementId: id,
           });
+        } else if (decoded.kind === "lib") {
+          const data = EX[decoded.value];
+          if (!data) continue;
+          const s = data.sets[0];
+          cards.push({
+            key: id,
+            kind: "leftleg",
+            label: "CATALOG",
+            color: "#3b82f6",
+            title: decoded.value,
+            sets: s ? `${s[0]}×${s[1]}` : "",
+            instruction: data.execution ?? "",
+            removable: true,
+            complementId: id,
+          });
         }
       }
 
@@ -1376,6 +1391,17 @@ export default function WorkoutView() {
                   sets: pt.sets,
                   instruction: pt.execution,
                   safety: pt.ptCues,
+                });
+              } else if (decoded.kind === "lib") {
+                const data = EX[decoded.value];
+                if (!data) continue;
+                const s = data.sets[0];
+                supps.push({
+                  type: "leftleg",
+                  name: decoded.value,
+                  sets: s ? `${s[0]}×${s[1]}` : "",
+                  instruction: data.execution ?? "",
+                  safety: "",
                 });
               }
             }

--- a/docs/superpowers/plans/2026-05-07-ad-hoc-supersets.md
+++ b/docs/superpowers/plans/2026-05-07-ad-hoc-supersets.md
@@ -1,0 +1,1160 @@
+# Ad-Hoc Supersets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the source-stacked complement picker with a universal search + filter chips, add catalog (`lib`) and free-text (`text`) complements, and render both new kinds under their parent exercise.
+
+**Architecture:** Two new `ComplementId` kinds (`lib|<exercise-name>`, `text|<base64>`) layered onto the existing pipe-delimited encoder. The picker keeps its source-availability `useMemo` but wraps the result in a `searchComplements()` helper that returns a flat result list filtered by query + filter-chip set. Render-side gets two new switch arms in `workout-view.tsx`'s two decode sites. No new files in `lib/` or `components/` — all picker logic stays inside `components/complement-picker.tsx`.
+
+**Tech Stack:** React 19, Next.js 16 App Router, TypeScript, Tailwind v4, Playwright/pytest E2E.
+
+**Spec:** `docs/superpowers/specs/2026-05-07-ad-hoc-supersets-design.md` (commit `b7a6b83`).
+
+**Branch:** `feat/ad-hoc-supersets`.
+
+---
+
+## File Structure
+
+| File | Why it changes |
+|---|---|
+| `components/complement-picker.tsx` | Add `encodeLibId` + `encodeTextId`; extend `decodeComplement` union; replace stacked-section render with search + chips + flat list + custom-text mode. |
+| `components/workout-view.tsx` | Two decode sites (lines ~990 and ~1319) get new switch arms for `lib` and `text` complement kinds. |
+| `e2e/test_ad_hoc_supersets.py` (new) | 7 E2E tests covering search, filter chips, catalog + custom-text add/remove, persistence. |
+
+No `lib/*` changes. No new files outside `components/` and `e2e/`.
+
+---
+
+## Task 1: Encode/decode + type union
+
+Pure additions to `components/complement-picker.tsx`. Adds `encodeLibId` and `encodeTextId` exports and extends `decodeComplement` to recognize the two new kinds. No UI yet.
+
+**Files:**
+- Modify: `components/complement-picker.tsx:32-73`
+
+- [ ] **Step 1: Read the existing decoder block to confirm shape**
+
+Run: `sed -n '32,73p' components/complement-picker.tsx`
+
+Expected output: shows `export type ComplementId = string`, `const SEP = "|"`, the five existing encoders, and `decodeComplement` returning a union of `"nearby" | "supp" | "core" | "mobility" | "pt"`.
+
+- [ ] **Step 2: Add `encodeLibId` and `encodeTextId` plus extend the union**
+
+Edit `components/complement-picker.tsx`. Replace the block from the `encodePTId` definition (around line 48) through the end of `decodeComplement` (around line 73) with:
+
+```ts
+export function encodePTId(ptId: string): ComplementId {
+  return `pt${SEP}${ptId}`;
+}
+
+export function encodeLibId(exerciseName: string): ComplementId {
+  return `lib${SEP}${exerciseName}`;
+}
+
+export function encodeTextId(text: string): ComplementId {
+  // base64 keeps the SEP delimiter safe even if the user types pipes
+  if (typeof btoa === "function") return `text${SEP}${btoa(text)}`;
+  return `text${SEP}${Buffer.from(text, "utf-8").toString("base64")}`;
+}
+
+export function decodeComplement(id: ComplementId): {
+  kind: "nearby" | "supp" | "core" | "mobility" | "pt" | "lib" | "text";
+  value: string;
+  sub?: string;
+} {
+  // Backward compat: try pipe first, fall back to colon for legacy IDs
+  const sep = id.includes("|") ? "|" : ":";
+  const [kind, ...rest] = id.split(sep);
+  if (kind === "nearby") {
+    return { kind: "nearby", value: rest[0], sub: rest.slice(1).join(sep) };
+  }
+  if (kind === "mob") {
+    return { kind: "mobility", value: rest.join(sep) };
+  }
+  if (kind === "core") {
+    return { kind: "core", value: rest.join(sep) };
+  }
+  if (kind === "pt") {
+    return { kind: "pt", value: rest.join(sep) };
+  }
+  if (kind === "lib") {
+    return { kind: "lib", value: rest.join(sep) };
+  }
+  if (kind === "text") {
+    const encoded = rest.join(sep);
+    let decoded = encoded;
+    try {
+      decoded =
+        typeof atob === "function"
+          ? atob(encoded)
+          : Buffer.from(encoded, "base64").toString("utf-8");
+    } catch {
+      decoded = encoded;
+    }
+    return { kind: "text", value: decoded };
+  }
+  return { kind: "supp", value: rest.join(sep) };
+}
+```
+
+- [ ] **Step 3: Typecheck the change**
+
+Run: `npx tsc --noEmit`
+
+Expected: 0 errors. (If errors mention `decodeComplement` consumers in `workout-view.tsx`, that is fine and expected — we will add the missing switch arms in Task 6 and Task 8.)
+
+If `tsc` complains that the consumer-side `decoded.kind` switch is non-exhaustive, the project does not enforce exhaustiveness — those switches are if/else-if chains that fall through, so the new kinds will simply produce no card until Tasks 6/8. Confirm by running `npm run build` next.
+
+- [ ] **Step 4: Run the production build**
+
+Run: `npm run build`
+
+Expected: build succeeds. The new exports compile, the switch chains in `workout-view.tsx` ignore the new kinds for now (no card rendered), no warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/complement-picker.tsx
+git commit -m "feat(supersets): encode/decode for lib and text complement kinds"
+```
+
+---
+
+## Task 2: `searchComplements` helper
+
+Pure helper inside `components/complement-picker.tsx`. Wraps the existing source-availability `useMemo` results into a single typed list and applies query + filter-chip filtering. No UI changes yet — the helper is unused after this task.
+
+**Files:**
+- Modify: `components/complement-picker.tsx` — append helper before the `ComplementButton` block
+
+- [ ] **Step 1: Read the picker imports + source-availability useMemo**
+
+Run: `sed -n '1,20p;165,215p' components/complement-picker.tsx`
+
+Expected: shows imports of `NEARBY_SUPERSETS`, `SUPPLEMENT_LEFT_LEG`, `SUPPLEMENT_CORE`, `SUPPLEMENT_EX`, `MOBILITY_SUPPLEMENTS` and the `useMemo` block populating `nearbyAvail`, `suppAvail`, `ptAvail`, `coreAvail`, `coreSubtitle`, `mobilityAvail`.
+
+- [ ] **Step 2: Add the `ComplementSource` type and `SearchResult` interface**
+
+Edit `components/complement-picker.tsx`. After the `decodeComplement` function definition (around line 95 after Task 1), insert:
+
+```ts
+// ── Search helpers ───────────────────────────────────────────────────────
+
+export type ComplementSource =
+  | "catalog"
+  | "nearby"
+  | "supp"
+  | "core"
+  | "mobility"
+  | "pt";
+
+export interface SearchResult {
+  id: ComplementId;
+  source: ComplementSource;
+  /** Short uppercase label shown on the chip (NEARBY / CATALOG / etc.). */
+  label: string;
+  /** Source accent color (matches existing color scheme). */
+  color: string;
+  /** Display title — exercise name or supplement name. */
+  title: string;
+  /** "3×10" or similar; empty string if not applicable. */
+  sets: string;
+  /** First line of execution / instruction. */
+  description: string;
+}
+
+interface SearchInputs {
+  nearbyAvail: NearbySuperset[];
+  suppAvail: Array<{ name: string; data: (typeof SUPPLEMENT_EX)[string] }>;
+  coreAvail: Array<{
+    name: string;
+    region: string;
+    data: (typeof SUPPLEMENT_EX)[string];
+  }>;
+  ptAvail: Array<{ id: string; name: string; sets: string; execution: string }>;
+  mobilityAvail: MobilitySupplement[];
+  /** All exercise display-names from EX (only searched when query is non-empty). */
+  catalogNames: string[];
+  /** EX lookup so we can build sets/description for catalog hits. */
+  catalogLookup: Record<string, { name: string; sets: [string, string][]; execution?: string }>;
+}
+
+const SOURCE_META: Record<ComplementSource, { label: string; color: string }> = {
+  catalog: { label: "CATALOG", color: "#3b82f6" },
+  nearby: { label: "NEARBY", color: "#14b8a6" },
+  supp: { label: "L-LEG", color: "#14b8a6" },
+  core: { label: "CORE", color: "#f97316" },
+  mobility: { label: "MOBILITY", color: "#0ea5e9" },
+  pt: { label: "PT", color: "#34d399" },
+};
+
+export function searchComplements(
+  query: string,
+  filters: Set<ComplementSource>,
+  inputs: SearchInputs,
+): SearchResult[] {
+  const q = query.trim().toLowerCase();
+  const results: SearchResult[] = [];
+
+  const want = (s: ComplementSource) => filters.size === 0 || filters.has(s);
+
+  if (want("nearby")) {
+    for (const ns of inputs.nearbyAvail) {
+      results.push({
+        id: encodeNearbyId(ns),
+        source: "nearby",
+        label: SOURCE_META.nearby.label,
+        color: SOURCE_META.nearby.color,
+        title: ns.title,
+        sets: ns.sets,
+        description: ns.instruction,
+      });
+    }
+  }
+
+  if (want("supp")) {
+    for (const { name, data } of inputs.suppAvail) {
+      const s = data.sets[0];
+      results.push({
+        id: encodeSuppId(name),
+        source: "supp",
+        label: SOURCE_META.supp.label,
+        color: SOURCE_META.supp.color,
+        title: name,
+        sets: `${s[0]}×${s[1]}`,
+        description: data.execution,
+      });
+    }
+  }
+
+  if (want("core")) {
+    for (const { name, region, data } of inputs.coreAvail) {
+      const s = data.sets[0];
+      results.push({
+        id: encodeCoreId(name),
+        source: "core",
+        label: region.toUpperCase(),
+        color: SOURCE_META.core.color,
+        title: name,
+        sets: `${s[0]}×${s[1]}`,
+        description: data.execution,
+      });
+    }
+  }
+
+  if (want("pt")) {
+    for (const ex of inputs.ptAvail) {
+      results.push({
+        id: encodePTId(ex.id),
+        source: "pt",
+        label: SOURCE_META.pt.label,
+        color: SOURCE_META.pt.color,
+        title: ex.name,
+        sets: ex.sets,
+        description: ex.execution,
+      });
+    }
+  }
+
+  if (want("mobility")) {
+    for (const m of inputs.mobilityAvail) {
+      const color =
+        m.kind === "breathing"
+          ? "#8b5cf6"
+          : m.kind === "stretch"
+            ? "#f59e0b"
+            : SOURCE_META.mobility.color;
+      const label =
+        m.kind === "breathing"
+          ? "BREATH"
+          : m.kind === "stretch"
+            ? "STRETCH"
+            : SOURCE_META.mobility.label;
+      results.push({
+        id: encodeMobilityId(m),
+        source: "mobility",
+        label,
+        color,
+        title: m.name,
+        sets: m.sets,
+        description: m.instruction,
+      });
+    }
+  }
+
+  // Catalog only surfaces when the user has typed something, OR when the
+  // catalog filter is the only one active (so they explicitly opted into
+  // browsing the full catalog without a query).
+  const catalogOnly = filters.size === 1 && filters.has("catalog");
+  if (want("catalog") && (q.length > 0 || catalogOnly)) {
+    for (const name of inputs.catalogNames) {
+      const data = inputs.catalogLookup[name];
+      if (!data) continue;
+      const s = data.sets[0];
+      results.push({
+        id: encodeLibId(name),
+        source: "catalog",
+        label: SOURCE_META.catalog.label,
+        color: SOURCE_META.catalog.color,
+        title: name,
+        sets: s ? `${s[0]}×${s[1]}` : "",
+        description: data.execution ?? "",
+      });
+    }
+  }
+
+  if (q.length === 0) return results;
+
+  // Substring match on title; exact-prefix matches sort before substring matches.
+  const filtered = results.filter((r) => r.title.toLowerCase().includes(q));
+  filtered.sort((a, b) => {
+    const aPrefix = a.title.toLowerCase().startsWith(q) ? 0 : 1;
+    const bPrefix = b.title.toLowerCase().startsWith(q) ? 0 : 1;
+    if (aPrefix !== bPrefix) return aPrefix - bPrefix;
+    return a.title.localeCompare(b.title);
+  });
+  return filtered;
+}
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npx tsc --noEmit`
+
+Expected: 0 errors. The helper is exported but unused, which TypeScript permits.
+
+- [ ] **Step 4: Build**
+
+Run: `npm run build`
+
+Expected: build succeeds, no new warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/complement-picker.tsx
+git commit -m "feat(supersets): searchComplements helper for unified query + filter"
+```
+
+---
+
+## Task 3: Picker UI — search input + flat result list
+
+Replace the stacked-by-source render block (lines ~272–429 of `complement-picker.tsx`) with a single search input on top and a flat list below. Filter chips and custom-text mode come in later tasks. The result list uses `searchComplements()` with no filters set, empty query → existing five sources flat-rendered; non-empty query → substring filter on title.
+
+**Files:**
+- Modify: `components/complement-picker.tsx:272-429` (replace render block)
+- Test: `e2e/test_ad_hoc_supersets.py` (new file)
+
+- [ ] **Step 1: Write the failing test for search input + flat list**
+
+Create `e2e/test_ad_hoc_supersets.py` with:
+
+```python
+"""E2E tests for the ad-hoc supersets / universal complement picker."""
+
+from playwright.sync_api import Page, expect
+
+
+def open_picker_for_first_exercise(page: Page) -> None:
+    """Open the complement picker for the first exercise on Today."""
+    page.get_by_test_id("tab-workout").click()
+    # Expand first exercise so its "+ complement" button is visible
+    first_row = page.get_by_test_id("exercise-row").first
+    first_row.click()
+    first_row.get_by_role("button", name="Add complement").first.click()
+    expect(page.get_by_test_id("complement-picker")).to_be_visible()
+
+
+def test_picker_has_search_and_results(app_page: Page):
+    """Picker renders a search input and shows a flat list of curated results."""
+    open_picker_for_first_exercise(app_page)
+    expect(app_page.get_by_test_id("complement-search")).to_be_visible()
+    # At least one result row appears with a source label
+    rows = app_page.get_by_test_id("complement-result")
+    expect(rows.first).to_be_visible()
+```
+
+- [ ] **Step 2: Run the new test (expect RED)**
+
+Run: `cd e2e && uv run pytest test_ad_hoc_supersets.py::test_picker_has_search_and_results -v`
+
+Expected: FAIL — `complement-search` testid is not present yet.
+
+- [ ] **Step 3: Replace the stacked-section render with search input + flat list**
+
+Edit `components/complement-picker.tsx`. First, add `useState` and `useEffect` to the React import at the top:
+
+```ts
+import React, { useEffect, useMemo, useState } from "react";
+```
+
+Then add the EX import near the existing `@/lib/supplements` import (around line 12):
+
+```ts
+import { EX } from "@/lib/exercises";
+```
+
+Now find the existing `useMemo` block ending with `return { nearbyAvail, suppAvail, ptAvail, coreAvail, coreSubtitle, mobilityAvail };` (around line 211). Immediately AFTER that closing brace and the dependency array `}, [...])`, add:
+
+```ts
+  const catalogNames = useMemo(() => Object.keys(EX), []);
+  const catalogLookup = useMemo(() => EX as unknown as SearchInputs["catalogLookup"], []);
+
+  const [query, setQuery] = useState("");
+  const [filters, setFilters] = useState<Set<ComplementSource>>(() => new Set());
+
+  const results = useMemo(
+    () =>
+      searchComplements(query, filters, {
+        nearbyAvail,
+        suppAvail,
+        coreAvail,
+        ptAvail: ptAvail.map((p) => ({
+          id: p.id,
+          name: p.name,
+          sets: p.sets,
+          execution: p.execution,
+        })),
+        mobilityAvail,
+        catalogNames,
+        catalogLookup,
+      }),
+    [query, filters, nearbyAvail, suppAvail, coreAvail, ptAvail, mobilityAvail, catalogNames, catalogLookup],
+  );
+```
+
+Next, replace the entire body block from the opening of the body div (around line 270, the `{/* Body */}` comment) through the closing `</div>` of that body div (around line 430, just before `{/* Footer */}`). The replacement:
+
+```tsx
+        {/* Body */}
+        <div className="overflow-y-auto flex-1 px-4 pb-6 pt-3">
+          <input
+            data-testid="complement-search"
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search complements..."
+            className="w-full mb-3 px-3 py-2 rounded-lg text-sm font-[inherit]"
+            style={{
+              background: "var(--color-bg)",
+              border: "1px solid var(--color-border)",
+              color: "var(--color-text)",
+            }}
+          />
+
+          {results.length === 0 && (
+            <div className="text-[12px] text-text-muted py-3 leading-relaxed">
+              {query
+                ? `No matches for "${query}".`
+                : "Nothing in reach right now. Open the edit sheet and select nearby equipment, or try adding generic quad sets below."}
+            </div>
+          )}
+
+          <div className="space-y-1.5">
+            {results.map((r) => (
+              <div data-testid="complement-result" key={r.id}>
+                <ComplementButton
+                  label={r.label}
+                  color={r.color}
+                  title={r.title}
+                  sets={r.sets}
+                  description={r.description}
+                  active={activeSet.has(r.id)}
+                  onClick={() => onToggle(r.id)}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+```
+
+Finally, delete the now-unused `hasAny` variable (around line 214).
+
+- [ ] **Step 4: Run the test (expect GREEN)**
+
+Run: `cd e2e && uv run pytest test_ad_hoc_supersets.py::test_picker_has_search_and_results -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full e2e suite to make sure nothing else regressed**
+
+Run: `cd e2e && uv run pytest -x --timeout=60 -q`
+
+Expected: all tests pass. Existing test files do not assert on the stacked-section testids (we use `complement-picker` testid only), so the suite stays green.
+
+If any test fails because it asserted on a stacked-section heading like "In reach (N)", treat it as test debt — patch the test to use `complement-result` instead and note in the commit.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/complement-picker.tsx e2e/test_ad_hoc_supersets.py
+git commit -m "feat(supersets): universal search input + flat result list"
+```
+
+---
+
+## Task 4: Filter chip row
+
+Adds the `All / Catalog / Nearby / Supp / Core / Mobility / PT` chip row beneath the search input. `All` = empty filter set (the default); clicking a specific source replaces the set with that single source; clicking `All` clears.
+
+**Files:**
+- Modify: `components/complement-picker.tsx` (chip row insertion)
+- Test: `e2e/test_ad_hoc_supersets.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `e2e/test_ad_hoc_supersets.py`:
+
+```python
+def test_filter_chip_narrows_results(app_page: Page):
+    """Activating a single filter chip removes results from other sources."""
+    open_picker_for_first_exercise(app_page)
+    # Establish baseline: at least one non-catalog row exists
+    pre_count = app_page.get_by_test_id("complement-result").count()
+    assert pre_count > 0
+
+    # Activate the Nearby chip — only NEARBY-labeled rows should remain
+    app_page.get_by_test_id("filter-chip-nearby").click()
+    rows = app_page.get_by_test_id("complement-result")
+    # Every visible result row's label badge must say NEARBY
+    for i in range(rows.count()):
+        badge = rows.nth(i).locator("span", has_text="NEARBY")
+        expect(badge).to_be_visible()
+```
+
+- [ ] **Step 2: Run the test (expect RED)**
+
+Run: `cd e2e && uv run pytest test_ad_hoc_supersets.py::test_filter_chip_narrows_results -v`
+
+Expected: FAIL — `filter-chip-nearby` does not exist.
+
+- [ ] **Step 3: Add the chip row**
+
+Edit `components/complement-picker.tsx`. Inside the body div, AFTER the search input and BEFORE the `{results.length === 0 && ...}` check, insert:
+
+```tsx
+          <div className="flex flex-wrap gap-1.5 mb-3">
+            {([
+              ["all", "All"],
+              ["catalog", "Catalog"],
+              ["nearby", "Nearby"],
+              ["supp", "L-Leg"],
+              ["core", "Core"],
+              ["mobility", "Mobility"],
+              ["pt", "PT"],
+            ] as const).map(([key, label]) => {
+              const isAll = key === "all";
+              const active = isAll
+                ? filters.size === 0
+                : filters.has(key as ComplementSource);
+              return (
+                <button
+                  key={key}
+                  data-testid={`filter-chip-${key}`}
+                  onClick={() => {
+                    if (isAll) {
+                      setFilters(new Set());
+                    } else {
+                      setFilters(new Set([key as ComplementSource]));
+                    }
+                  }}
+                  className="text-[10px] font-bold uppercase tracking-wider rounded-full px-2.5 py-1 cursor-pointer font-[inherit]"
+                  style={{
+                    background: active
+                      ? "var(--color-accent)22"
+                      : "var(--color-bg)",
+                    border: `1px solid ${active ? "var(--color-accent)" : "var(--color-border)"}`,
+                    color: active ? "var(--color-accent)" : "var(--color-text-muted)",
+                  }}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+```
+
+- [ ] **Step 4: Run the test (expect GREEN)**
+
+Run: `cd e2e && uv run pytest test_ad_hoc_supersets.py::test_filter_chip_narrows_results -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/complement-picker.tsx e2e/test_ad_hoc_supersets.py
+git commit -m "feat(supersets): filter chips for source-narrowing"
+```
+
+---
+
+## Task 5: Catalog source — search EX
+
+Wire the full `EX` exercise catalog into search results. Empty query keeps the catalog hidden (too long); typed query OR `Catalog`-only filter surfaces matching catalog entries. The `searchComplements` helper from Task 2 already handles both branches — this task just needs an E2E to confirm.
+
+**Files:**
+- Test: `e2e/test_ad_hoc_supersets.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `e2e/test_ad_hoc_supersets.py`:
+
+```python
+def test_search_finds_catalog_exercise(app_page: Page):
+    """Typing 'bench' surfaces a CATALOG-labeled result from EX."""
+    open_picker_for_first_exercise(app_page)
+    app_page.get_by_test_id("complement-search").fill("bench")
+    # Wait for re-render
+    rows = app_page.get_by_test_id("complement-result")
+    # At least one row exists with the CATALOG label
+    catalog_rows = rows.filter(has_text="CATALOG")
+    expect(catalog_rows.first).to_be_visible()
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cd e2e && uv run pytest test_ad_hoc_supersets.py::test_search_finds_catalog_exercise -v`
+
+Expected: PASS — Tasks 2 + 3 already wired this. If it fails, double-check that `catalogNames` and `catalogLookup` are passed to `searchComplements()` in Task 3 and that `EX` is imported.
+
+- [ ] **Step 3: Commit (test only — no code change)**
+
+```bash
+git add e2e/test_ad_hoc_supersets.py
+git commit -m "test(supersets): catalog search surfaces EX entries"
+```
+
+---
+
+## Task 6: Render `lib` complement in workout-view
+
+Adds the missing switch arm for `decoded.kind === "lib"` to BOTH decode sites in `components/workout-view.tsx` (around lines 990 and 1319). A `lib` complement looks up `EX[name]`, renders with sets from `EX[name].sets[0]`, and is removable like other user-opted complements.
+
+**Files:**
+- Modify: `components/workout-view.tsx` (two switch insertions)
+- Test: `e2e/test_ad_hoc_supersets.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `e2e/test_ad_hoc_supersets.py`:
+
+```python
+def test_add_lib_complement(app_page: Page):
+    """Tapping a CATALOG result adds a lib-kind card under the parent exercise."""
+    open_picker_for_first_exercise(app_page)
+    app_page.get_by_test_id("complement-search").fill("bench")
+    catalog_rows = app_page.get_by_test_id("complement-result").filter(has_text="CATALOG")
+    first = catalog_rows.first
+    title = first.locator("span.text-sm").inner_text()  # exercise name
+    first.click()
+    # Close picker
+    app_page.get_by_role("button", name="Done").click()
+    # The first exercise row now has a superset-card with that title
+    cards = app_page.get_by_test_id("superset-card")
+    expect(cards.filter(has_text=title).first).to_be_visible()
+```
+
+- [ ] **Step 2: Run the test (expect RED)**
+
+Run: `cd e2e && uv run pytest test_ad_hoc_supersets.py::test_add_lib_complement -v`
+
+Expected: FAIL — the `lib` card does not render yet (decode falls through).
+
+- [ ] **Step 3: Add the `lib` arm to the first decode site**
+
+Edit `components/workout-view.tsx`. Find the `else if (decoded.kind === "pt")` block ending around line 1085 (right before the closing `}` of the `for (const id of userComps)` loop in `buildSupersetCards`). Insert AFTER the `pt` block and BEFORE the loop's closing `}`:
+
+```ts
+        } else if (decoded.kind === "lib") {
+          const data = EX[decoded.value];
+          if (!data) continue;
+          const s = data.sets[0];
+          cards.push({
+            key: id,
+            kind: "leftleg",
+            label: "CATALOG",
+            color: "#3b82f6",
+            title: decoded.value,
+            sets: s ? `${s[0]}×${s[1]}` : "",
+            instruction: data.execution ?? "",
+            removable: true,
+            complementId: id,
+          });
+```
+
+- [ ] **Step 4: Add the `lib` arm to the second decode site (focus mode)**
+
+In the same file, find the `else if (decoded.kind === "pt")` block in the focus-mode supps loop ending around line 1380 (right before the closing `}` of `for (const id of userComps)` inside the focus-mode block, which itself ends with `return { name: nm, ex: exItem, supplements: ... }`). Insert AFTER the `pt` block and BEFORE the loop's closing `}`:
+
+```ts
+              } else if (decoded.kind === "lib") {
+                const data = EX[decoded.value];
+                if (!data) continue;
+                const s = data.sets[0];
+                supps.push({
+                  type: "leftleg",
+                  name: decoded.value,
+                  sets: s ? `${s[0]}×${s[1]}` : "",
+                  instruction: data.execution ?? "",
+                });
+```
+
+- [ ] **Step 5: Run the test (expect GREEN)**
+
+Run: `cd e2e && uv run pytest test_ad_hoc_supersets.py::test_add_lib_complement -v`
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the full e2e suite**
+
+Run: `cd e2e && uv run pytest -x --timeout=60 -q`
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add components/workout-view.tsx e2e/test_ad_hoc_supersets.py
+git commit -m "feat(supersets): render catalog (lib) complement cards under exercises"
+```
+
+---
+
+## Task 7: Custom-text input mode in picker
+
+Adds a "Custom text" pill below the chips that swaps the search input for a free-text input + Save button. Save creates a `text|<base64>` complement and closes the picker. No render-side change yet — that lands in Task 8.
+
+**Files:**
+- Modify: `components/complement-picker.tsx`
+
+- [ ] **Step 1: Add custom-text mode state and the toggle UI**
+
+Edit `components/complement-picker.tsx`. Near the existing `useState` calls (added in Task 3), add:
+
+```ts
+  const [customMode, setCustomMode] = useState(false);
+  const [customText, setCustomText] = useState("");
+```
+
+Inside the body div, immediately AFTER the filter chip row and BEFORE the search input (note: when `customMode` is true, we hide the search input + chips and show the custom UI instead), refactor to wrap conditionally. The body block becomes:
+
+```tsx
+        {/* Body */}
+        <div className="overflow-y-auto flex-1 px-4 pb-6 pt-3">
+          {!customMode && (
+            <>
+              <input
+                data-testid="complement-search"
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search complements..."
+                className="w-full mb-3 px-3 py-2 rounded-lg text-sm font-[inherit]"
+                style={{
+                  background: "var(--color-bg)",
+                  border: "1px solid var(--color-border)",
+                  color: "var(--color-text)",
+                }}
+              />
+
+              <div className="flex flex-wrap gap-1.5 mb-3">
+                {/* (chip row from Task 4 — unchanged) */}
+              </div>
+
+              <button
+                data-testid="custom-text-toggle"
+                onClick={() => setCustomMode(true)}
+                className="mb-3 text-[11px] font-bold rounded-full px-2.5 py-1 cursor-pointer font-[inherit]"
+                style={{
+                  background: "var(--color-bg)",
+                  border: "1px solid var(--color-border)",
+                  color: "var(--color-text-muted)",
+                }}
+              >
+                + Custom text
+              </button>
+
+              {results.length === 0 && (
+                <div className="text-[12px] text-text-muted py-3 leading-relaxed">
+                  {query
+                    ? `No matches for "${query}".`
+                    : "Nothing in reach right now. Open the edit sheet and select nearby equipment, or try adding generic quad sets below."}
+                </div>
+              )}
+
+              <div className="space-y-1.5">
+                {results.map((r) => (
+                  <div data-testid="complement-result" key={r.id}>
+                    <ComplementButton
+                      label={r.label}
+                      color={r.color}
+                      title={r.title}
+                      sets={r.sets}
+                      description={r.description}
+                      active={activeSet.has(r.id)}
+                      onClick={() => onToggle(r.id)}
+                    />
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+
+          {customMode && (
+            <div data-testid="custom-text-form">
+              <div className="flex gap-2 mb-3">
+                <input
+                  data-testid="custom-text-input"
+                  type="text"
+                  value={customText}
+                  onChange={(e) => setCustomText(e.target.value)}
+                  placeholder="Type your superset..."
+                  autoFocus
+                  className="flex-1 px-3 py-2 rounded-lg text-sm font-[inherit]"
+                  style={{
+                    background: "var(--color-bg)",
+                    border: "1px solid var(--color-border)",
+                    color: "var(--color-text)",
+                  }}
+                />
+                <button
+                  data-testid="custom-text-save"
+                  onClick={() => {
+                    const trimmed = customText.trim();
+                    if (!trimmed) return;
+                    onToggle(encodeTextId(trimmed));
+                    setCustomText("");
+                    setCustomMode(false);
+                    onClose();
+                  }}
+                  className="px-3 rounded-lg text-sm font-bold cursor-pointer font-[inherit]"
+                  style={{
+                    background: "var(--color-accent)22",
+                    border: "1px solid var(--color-accent)",
+                    color: "var(--color-accent)",
+                  }}
+                >
+                  Save
+                </button>
+              </div>
+              <button
+                data-testid="custom-text-cancel"
+                onClick={() => {
+                  setCustomMode(false);
+                  setCustomText("");
+                }}
+                className="text-[11px] text-text-muted cursor-pointer font-[inherit]"
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+        </div>
+```
+
+The chip row inside the `<>` fragment must keep the actual chip-rendering code from Task 4 (don't ship the placeholder comment). The literal chip block to use:
+
+```tsx
+              <div className="flex flex-wrap gap-1.5 mb-3">
+                {([
+                  ["all", "All"],
+                  ["catalog", "Catalog"],
+                  ["nearby", "Nearby"],
+                  ["supp", "L-Leg"],
+                  ["core", "Core"],
+                  ["mobility", "Mobility"],
+                  ["pt", "PT"],
+                ] as const).map(([key, label]) => {
+                  const isAll = key === "all";
+                  const active = isAll
+                    ? filters.size === 0
+                    : filters.has(key as ComplementSource);
+                  return (
+                    <button
+                      key={key}
+                      data-testid={`filter-chip-${key}`}
+                      onClick={() => {
+                        if (isAll) {
+                          setFilters(new Set());
+                        } else {
+                          setFilters(new Set([key as ComplementSource]));
+                        }
+                      }}
+                      className="text-[10px] font-bold uppercase tracking-wider rounded-full px-2.5 py-1 cursor-pointer font-[inherit]"
+                      style={{
+                        background: active
+                          ? "var(--color-accent)22"
+                          : "var(--color-bg)",
+                        border: `1px solid ${active ? "var(--color-accent)" : "var(--color-border)"}`,
+                        color: active ? "var(--color-accent)" : "var(--color-text-muted)",
+                      }}
+                    >
+                      {label}
+                    </button>
+                  );
+                })}
+              </div>
+```
+
+- [ ] **Step 2: Typecheck and build**
+
+Run: `npm run build`
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Confirm existing tests still pass**
+
+Run: `cd e2e && uv run pytest test_ad_hoc_supersets.py -v`
+
+Expected: all 4 tests so far pass (`test_picker_has_search_and_results`, `test_filter_chip_narrows_results`, `test_search_finds_catalog_exercise`, `test_add_lib_complement`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/complement-picker.tsx
+git commit -m "feat(supersets): custom-text input mode in picker"
+```
+
+---
+
+## Task 8: Render `text` complement in workout-view
+
+Adds the `decoded.kind === "text"` switch arm to BOTH decode sites in `components/workout-view.tsx`. A `text` complement renders as a thin gray card with the user's typed string and a remove button.
+
+**Files:**
+- Modify: `components/workout-view.tsx`
+- Test: `e2e/test_ad_hoc_supersets.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `e2e/test_ad_hoc_supersets.py`:
+
+```python
+def test_add_custom_text_complement(app_page: Page):
+    """Custom-text save creates a card with the typed string under the exercise."""
+    open_picker_for_first_exercise(app_page)
+    app_page.get_by_test_id("custom-text-toggle").click()
+    app_page.get_by_test_id("custom-text-input").fill("Cossack squat 3x8")
+    app_page.get_by_test_id("custom-text-save").click()
+    expect(app_page.get_by_test_id("complement-picker")).not_to_be_visible()
+    cards = app_page.get_by_test_id("superset-card")
+    expect(cards.filter(has_text="Cossack squat 3x8").first).to_be_visible()
+
+
+def test_remove_custom_text(app_page: Page):
+    """Tapping the × on a custom-text card removes it from the workout."""
+    open_picker_for_first_exercise(app_page)
+    app_page.get_by_test_id("custom-text-toggle").click()
+    app_page.get_by_test_id("custom-text-input").fill("My custom move")
+    app_page.get_by_test_id("custom-text-save").click()
+    card = app_page.get_by_test_id("superset-card").filter(has_text="My custom move").first
+    expect(card).to_be_visible()
+    card.get_by_role("button", name="Remove complement").click()
+    expect(app_page.get_by_test_id("superset-card").filter(has_text="My custom move")).to_have_count(0)
+```
+
+- [ ] **Step 2: Run the tests (expect RED)**
+
+Run: `cd e2e && uv run pytest test_ad_hoc_supersets.py::test_add_custom_text_complement test_ad_hoc_supersets.py::test_remove_custom_text -v`
+
+Expected: FAIL — text decode falls through, no card renders.
+
+- [ ] **Step 3: Add the `text` arm to the first decode site**
+
+Edit `components/workout-view.tsx`. Find the `lib` arm added in Task 6 inside `buildSupersetCards`. Immediately AFTER it (still inside the `for (const id of userComps)` loop), add:
+
+```ts
+        } else if (decoded.kind === "text") {
+          cards.push({
+            key: id,
+            kind: "leftleg",
+            label: "CUSTOM",
+            color: "#71717a",
+            title: decoded.value,
+            sets: "",
+            instruction: "",
+            removable: true,
+            complementId: id,
+          });
+```
+
+- [ ] **Step 4: Add the `text` arm to the second decode site (focus mode)**
+
+In the same file, find the `lib` arm added in Task 6 inside the focus-mode supps loop. Immediately AFTER it, add:
+
+```ts
+              } else if (decoded.kind === "text") {
+                supps.push({
+                  type: "leftleg",
+                  name: decoded.value,
+                  sets: "",
+                  instruction: "",
+                });
+```
+
+- [ ] **Step 5: Run the tests (expect GREEN)**
+
+Run: `cd e2e && uv run pytest test_ad_hoc_supersets.py::test_add_custom_text_complement test_ad_hoc_supersets.py::test_remove_custom_text -v`
+
+Expected: both PASS.
+
+- [ ] **Step 6: Run the full file**
+
+Run: `cd e2e && uv run pytest test_ad_hoc_supersets.py -v`
+
+Expected: 6 tests passing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add components/workout-view.tsx e2e/test_ad_hoc_supersets.py
+git commit -m "feat(supersets): render custom (text) complement cards under exercises"
+```
+
+---
+
+## Task 9: Persistence E2E
+
+Confirms both `lib` and `text` complements survive a page reload (they ride on the existing `dayState.complements` localStorage path so this should pass without code changes — but the spec calls it out as a required test, and it guards against future regressions).
+
+**Files:**
+- Test: `e2e/test_ad_hoc_supersets.py`
+
+- [ ] **Step 1: Write the test**
+
+Append to `e2e/test_ad_hoc_supersets.py`:
+
+```python
+def test_complement_persistence(app_page: Page):
+    """A lib complement and a text complement both survive a page reload."""
+    open_picker_for_first_exercise(app_page)
+
+    # Add a lib complement
+    app_page.get_by_test_id("complement-search").fill("bench")
+    catalog_rows = app_page.get_by_test_id("complement-result").filter(has_text="CATALOG")
+    catalog_title = catalog_rows.first.locator("span.text-sm").inner_text()
+    catalog_rows.first.click()
+
+    # Switch to custom-text and add one
+    app_page.get_by_test_id("custom-text-toggle").click()
+    app_page.get_by_test_id("custom-text-input").fill("Persisted custom move")
+    app_page.get_by_test_id("custom-text-save").click()
+
+    # Reload
+    app_page.reload()
+    app_page.wait_for_selector("[data-testid='app-container']", timeout=15000)
+
+    # Both cards still visible (re-expand the first row first)
+    first_row = app_page.get_by_test_id("exercise-row").first
+    first_row.click()
+    cards = app_page.get_by_test_id("superset-card")
+    expect(cards.filter(has_text=catalog_title).first).to_be_visible()
+    expect(cards.filter(has_text="Persisted custom move").first).to_be_visible()
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cd e2e && uv run pytest test_ad_hoc_supersets.py::test_complement_persistence -v`
+
+Expected: PASS — `dayState.complements` already persists via the existing `nwb_complements_<date>` localStorage key, no code change needed.
+
+- [ ] **Step 3: Commit (test only)**
+
+```bash
+git add e2e/test_ad_hoc_supersets.py
+git commit -m "test(supersets): persistence across reload for lib + text complements"
+```
+
+---
+
+## Task 10: Build, full regression, PR, merge
+
+Final gate. Confirms typecheck + production build + full E2E suite + cleanup, then ships to dev and dev → main.
+
+- [ ] **Step 1: Typecheck**
+
+Run: `npx tsc --noEmit`
+
+Expected: 0 errors.
+
+- [ ] **Step 2: Production build**
+
+Run: `npm run build`
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Full E2E suite**
+
+Run: `cd e2e && uv run pytest --timeout=60`
+
+Expected: all tests pass (97 existing + 7 new from `test_ad_hoc_supersets.py` = 104 total).
+
+If any pre-existing test fails, investigate before proceeding. Likely culprits: a test that asserted on the now-removed source-section heading copy (e.g. "In reach (N)" or "Left-leg rehab (N)"). Patch those tests to use `complement-result` testid.
+
+- [ ] **Step 4: Push the branch and open a PR to dev**
+
+```bash
+git push -u origin feat/ad-hoc-supersets
+gh pr create --base dev --title "feat: ad-hoc supersets — universal search + free-text complement" --body "$(cat <<'EOF'
+## Summary
+- Replaces the source-stacked complement picker with a universal search input + filter chips
+- Adds two new ComplementId kinds: `lib|<exercise-name>` (any catalog exercise) and `text|<base64>` (free text)
+- Renders both new kinds as cards under the parent exercise; both removable like existing complements
+
+## Test plan
+- [x] `e2e/test_ad_hoc_supersets.py` — 7 new tests covering search, filter chips, catalog/text add, removal, persistence
+- [x] Full E2E suite green
+- [x] Manual smoke on Safari mobile
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Wait for CI green, then merge to dev**
+
+Run: `gh pr checks --watch` (block until green)
+
+Then: `gh pr merge --squash --delete-branch`
+
+- [ ] **Step 6: Fast-forward dev → main**
+
+```bash
+git fetch origin
+git checkout main
+git pull --ff-only origin main
+git merge --ff-only origin/dev
+git push origin main
+```
+
+- [ ] **Step 7: Verify Vercel production deploy**
+
+Run: `vercel inspect $(vercel ls --prod -1 nwb-plan | tail -1)` or check https://nfit.93.fyi for the new picker.
+
+Expected: production reflects the new picker UX.
+
+---
+
+## Self-review checklist
+
+**Spec coverage (against `docs/superpowers/specs/2026-05-07-ad-hoc-supersets-design.md`):**
+- ✅ Universal search input (Goal #1) → Task 3
+- ✅ Filter chips (Goal #2, #3) → Task 4
+- ✅ Substring match + prefix-first sort (Goal #4) → Task 2
+- ✅ Empty search shows curated default (Goal #5) → Task 2 + 3
+- ✅ Custom-text toggle (Goal #6) → Task 7
+- ✅ Two new ComplementId kinds + encode/decode (Goal #7) → Task 1
+- ✅ Render `lib` and `text` under exercise (Goal #8) → Task 6 + 8
+- ✅ All 7 E2E tests from spec → Tasks 3, 4, 5, 6, 8, 9 (test 7 `test_remove_custom_text` is in Task 8)
+
+**Non-goals (explicitly NOT covered, matching spec):**
+- ✅ HEP search excluded — `searchComplements` does not iterate `HEP_EXERCISES`
+- ✅ Reordering, editing custom text, fuzzy matching, history search — none included
+
+**Type consistency:**
+- `ComplementSource` defined in Task 2 and used in Tasks 3, 4 — consistent.
+- `SearchResult` defined in Task 2 and consumed in Task 3 — fields (`id`, `source`, `label`, `color`, `title`, `sets`, `description`) match.
+- `encodeLibId(name: string)` and `encodeTextId(text: string)` signatures consistent across Tasks 1, 7.

--- a/docs/superpowers/specs/2026-05-07-ad-hoc-supersets-design.md
+++ b/docs/superpowers/specs/2026-05-07-ad-hoc-supersets-design.md
@@ -25,7 +25,7 @@ This feature adds catalog search and free-text complements, and at the same time
 5. Empty search shows a curated default list (the existing five sections, just rendered as flat cards in source order).
 6. Add a "Custom text" toggle that swaps the search input for a single-line text input + Save button. Saves a free-text complement.
 7. Two new `ComplementId` kinds and encode/decode functions:
-   - `lib|<exercise-id>` — references an entry in `EX` by its `id`
+   - `lib|<exercise-name>` — references an entry in `EX` by its display-name key (e.g. `lib|Barbell Floor Press`). The `EX` Record is keyed by display name, not by the `Exercise.id` snake_case field.
    - `text|<base64-encoded-string>` — embeds the user's free-text inline (so it round-trips through localStorage)
 8. Both new complement kinds render under the exercise the same way existing complements do — a card below the exercise row. `lib` complements use the catalog data (sets/reps from `EX[id]`); `text` complements render as a thin card with just the typed string + a check.
 
@@ -59,8 +59,8 @@ Two new `ComplementId` kinds appended to the existing union:
 
 ```ts
 // components/complement-picker.tsx
-export function encodeLibId(exId: string): ComplementId {
-  return `lib${SEP}${exId}`;
+export function encodeLibId(exerciseName: string): ComplementId {
+  return `lib${SEP}${exerciseName}`;
 }
 
 export function encodeTextId(text: string): ComplementId {
@@ -73,7 +73,7 @@ export function decodeComplement(id: ComplementId): {
   sub?: string;
 } {
   // existing decoder, plus:
-  // - "lib" → returns the exercise id (call site looks up in EX)
+  // - "lib" → returns the exercise name (call site looks up in EX)
   // - "text" → returns base64-decoded user string
 }
 ```

--- a/docs/superpowers/specs/2026-05-07-ad-hoc-supersets-design.md
+++ b/docs/superpowers/specs/2026-05-07-ad-hoc-supersets-design.md
@@ -1,0 +1,209 @@
+# Ad-Hoc Supersets — Design Spec
+
+**Date:** 2026-05-07
+**Status:** Approved (pending Karl's spec review)
+**Source brainstorm:** This conversation, captured initially in [issue #114](https://github.com/karlmarx/nwb-plan/issues/114)
+**Branch:** `feat/ad-hoc-supersets`
+**Predecessor:** PT HEP Daily (PR #115, merged to main as of `0c47ef6`)
+
+## Background
+
+The existing `components/complement-picker.tsx` modal lets the user add a complement (superset partner) to any exercise from one of five curated sources: nearby supersets, left-leg supplements, day-specific core, mobility drills, phase-gated PT exercises. Each source has its own section in the modal; finding what you want requires knowing which source-bucket it lives in.
+
+Two real-world gaps:
+1. **The full exercise catalog (`lib/exercises.ts`'s `EX`) is not searchable as a complement.** If you want to superset an arbitrary lift (e.g., "Glute Bridge" to pair with "Bench Press"), there's no path — the picker only surfaces curated complements.
+2. **One-off custom additions have no path.** If you do a Cossack squat that nobody's built into the data, you can't track it as a complement.
+
+This feature adds catalog search and free-text complements, and at the same time replaces the source-tab UX with a single universal search box + filter chips. The picker becomes "type what you want, find it everywhere" instead of "remember which source-tab it lives in."
+
+## Goals
+
+1. Replace the picker's stacked-by-source layout with a single search input at the top of the modal body.
+2. Add filter chips below the search (`All / Catalog / Nearby / Supplement / Core / Mobility / PT`) — toggle-able, multi-select, default `All`.
+3. New search hits all sources at once: `EX` (catalog), `SUPPLEMENT_EX`, `MOBILITY_SUPPLEMENTS`, `PT_EXERCISES`, `NEARBY_SUPERSETS`, `SUPPLEMENT_CORE` (current day's only).
+4. Substring match on display name, case-insensitive. Exact-prefix matches sorted before substring matches. No fuzzy library — keep it dependency-free.
+5. Empty search shows a curated default list (the existing five sections, just rendered as flat cards in source order).
+6. Add a "Custom text" toggle that swaps the search input for a single-line text input + Save button. Saves a free-text complement.
+7. Two new `ComplementId` kinds and encode/decode functions:
+   - `lib|<exercise-id>` — references an entry in `EX` by its `id`
+   - `text|<base64-encoded-string>` — embeds the user's free-text inline (so it round-trips through localStorage)
+8. Both new complement kinds render under the exercise the same way existing complements do — a card below the exercise row. `lib` complements use the catalog data (sets/reps from `EX[id]`); `text` complements render as a thin card with just the typed string + a check.
+
+## Non-goals
+
+- Reordering complements within an exercise.
+- Editing a custom-text complement after it's added (delete + re-add for v1).
+- Searching across user-saved workout history (i.e., "show me what I supersetted last time").
+- Advanced fuzzy matching (Fuse.js, Levenshtein, etc.).
+- Cloud-syncing custom-text complements separately from `dayState`.
+- Searching `HEP_EXERCISES` — HEP is a daily floor, not a workout complement. Out of scope.
+- Visual redesign of the existing complement card (`ComplementButton`) — same shape, just used in new contexts.
+
+## Architecture
+
+One file heavily modified, three small touch-ups. No new files.
+
+### Modified files
+
+| File | What changes |
+|---|---|
+| `components/complement-picker.tsx` | Add `encodeLibId`, `encodeTextId` and update `decodeComplement` to handle the two new kinds. Replace the stacked-sections render with a search input, filter chips, and a flat result list. Add a "Custom text" toggle. |
+| `components/workout-view.tsx` | In the complement-card render code (existing `decodeComplement` switch around line 990 and 1319), add cases for `lib` and `text` kinds. Render `lib` using `EX[id]` data; render `text` using the inline string. |
+| `e2e/test_complement_picker.py` *or* a new file `e2e/test_ad_hoc_supersets.py` | New E2E tests: catalog search, filter chip behavior, custom text add, both render correctly under their parent exercise, persistence. |
+
+(Pick `e2e/test_ad_hoc_supersets.py` if no `test_complement_picker.py` exists, otherwise extend the existing one. Implementation will check.)
+
+## Data model
+
+Two new `ComplementId` kinds appended to the existing union:
+
+```ts
+// components/complement-picker.tsx
+export function encodeLibId(exId: string): ComplementId {
+  return `lib${SEP}${exId}`;
+}
+
+export function encodeTextId(text: string): ComplementId {
+  return `text${SEP}${btoa(text)}`;  // base64 to survive the SEP delimiter
+}
+
+export function decodeComplement(id: ComplementId): {
+  kind: "nearby" | "supp" | "core" | "mobility" | "pt" | "lib" | "text";
+  value: string;
+  sub?: string;
+} {
+  // existing decoder, plus:
+  // - "lib" → returns the exercise id (call site looks up in EX)
+  // - "text" → returns base64-decoded user string
+}
+```
+
+`dayState.complements: Record<exerciseName, ComplementId[]>` storage shape is unchanged. The new kinds are just two more strings in the same array.
+
+## Search algorithm
+
+Single function, called on every keystroke (debounced 100ms via existing patterns or just inline).
+
+```ts
+function searchComplements(
+  query: string,
+  filters: Set<ComplementSource>,  // "catalog" | "nearby" | "supp" | "core" | "mobility" | "pt"
+  ctx: { exerciseRequires, exerciseCategory, workoutKey, nearbySelections, ptPhase },
+): SearchResult[];
+
+interface SearchResult {
+  id: ComplementId;
+  title: string;
+  source: ComplementSource;
+  sets?: string;       // "3×10" or similar
+  description: string; // first line of execution / instructions
+  color: string;       // existing source-color (NEARBY=teal, CORE=orange, etc.)
+}
+```
+
+Behavior:
+- Empty query, all filters: returns the full curated set (existing nearby/supp/pt/core/mobility lists in source order). Catalog NOT included by default — too long; only surfaces with a non-empty query or when the `Catalog` chip is the only active filter.
+- Non-empty query: substring match on `title.toLowerCase()` against `query.toLowerCase()`. Case-insensitive. Sort: exact prefix matches first, then alphabetical within each match group.
+- Filters: source must be in the active filter set to be included. `All` chip toggles all on/off.
+
+The existing source-availability logic (`nearbyAvail`, `suppAvail`, etc., from `useMemo`) is reused — wrapped behind `searchComplements`.
+
+## UX
+
+### Picker modal layout
+
+```
+┌────────────────────────────────────────┐
+│  Add complement                  [×]   │
+│  Equipment-aware suggestions           │
+├────────────────────────────────────────┤
+│  [🔍 Search complements...        ]    │
+│  [All] [Catalog] [Nearby] [Supp]       │
+│  [Core] [Mobility] [PT]                │
+│                                         │
+│  [+ Custom text]                       │
+│                                         │
+│  ┌──────────────────────────────────┐  │
+│  │ NEARBY  Glute Bridge × 3 reps  ✓ │  │
+│  └──────────────────────────────────┘  │
+│  ┌──────────────────────────────────┐  │
+│  │ CATALOG Cable Pull-down · 3×10   │  │
+│  └──────────────────────────────────┘  │
+│  ...                                   │
+└────────────────────────────────────────┘
+```
+
+- Search input: full-width, sticky to top of body. Placeholder: "Search complements...".
+- Filter chips: horizontally scrollable on mobile if overflow. `All` is mutually exclusive with the others (clicking `All` deselects others; clicking a specific source deselects `All`).
+- "Custom text" pill: tap → search input morphs into a free-text input + "Save" button. Esc / outside-tap returns to search mode.
+- Results list: flat scrollable list, each row uses the existing `ComplementButton` shape, sorted by source-grouping when no query, search-relevance when query present.
+
+### Custom text input mode
+
+```
+┌────────────────────────────────────────┐
+│  Add complement                  [×]   │
+├────────────────────────────────────────┤
+│  [Type your superset...     ] [Save]   │
+│                                         │
+│  Cancel                                 │
+└────────────────────────────────────────┘
+```
+
+- Single line, `<input>`, Enter or Save button commits.
+- "Save" creates a `text|<base64>` complement, calls `onToggle(id)`, and closes the modal.
+- Cancel returns to search mode without saving.
+- Empty input on Save = no-op (don't add empty complements).
+
+### Rendered complements (under the exercise)
+
+`lib` kind:
+- Card uses the catalog name from `EX[id].name`.
+- Sets/reps: shows `EX[id].sets[0]` (first set spec — same convention used elsewhere).
+- Color: a new accent for catalog complements, e.g. `#3b82f6` (blue) — distinguishes from nearby (teal), core (orange), supp (purple), mobility (cyan), pt (pink). Final color picked during implementation, not blocking.
+- Tap to mark done (uses existing `completedSupersets` state).
+
+`text` kind:
+- Card uses the typed string as the title.
+- No sets/reps line.
+- Subtle "Custom" label tag.
+- Color: a neutral `#71717a` (gray) — distinct from all curated kinds.
+- Tap to mark done. Long-press (or a small × on the card) removes — since custom text can't be re-found via search, removal needs a clear path.
+
+## Testing
+
+E2E tests in `e2e/test_ad_hoc_supersets.py` (new file):
+
+1. **`test_open_picker_shows_search_and_chips`** — open complement picker on any exercise; assert search input + filter chips present.
+2. **`test_search_finds_catalog_exercise`** — type "bench"; assert `EX["barbell_floor_press"]` (or similar) appears as a search result with `CATALOG` label.
+3. **`test_filter_chip_narrows_results`** — search "press"; toggle off `Catalog` chip; assert no `CATALOG`-labeled rows remain (only nearby/supp/etc. matches).
+4. **`test_add_custom_text_complement`** — tap "Custom text"; type "Cossack squat 3x8"; tap Save; assert modal closes; assert custom card renders under the parent exercise with the typed text.
+5. **`test_add_lib_complement`** — search and tap a catalog result; assert modal closes; assert the lib card renders under the parent exercise with `EX[id].name` and sets/reps.
+6. **`test_complement_persistence`** — add a custom text + a lib complement; reload page; assert both still present under the exercise.
+7. **`test_remove_custom_text`** — add custom text; tap remove; assert card disappears, localStorage updated.
+
+## Build sequence
+
+1. **Encode/decode.** Add `encodeLibId`, `encodeTextId`, and extend `decodeComplement`. Type-check passes.
+2. **Search function.** Pure helper `searchComplements(query, filters, ctx)` that wraps the existing source-availability logic. Unit-testable conceptually — but no test runner, so behavior gets covered by E2E.
+3. **Picker UI v1.** Replace stacked sections with search input + flat result list. No filter chips yet, no custom-text yet. Existing complements still work.
+4. **Filter chips.** Add the `All / Catalog / Nearby / Supplement / Core / Mobility / PT` chip row.
+5. **Catalog source.** Wire `EX` into `searchComplements`. Empty-query still excludes catalog (too long); non-empty query or `Catalog`-only filter includes it.
+6. **Custom-text mode.** Add the toggle + free-text input + Save handler.
+7. **Render `lib` kind.** Update the complement-card render in `workout-view.tsx` to handle `lib` complements (look up `EX[id]`, use `EX[id].name`, sets, etc.).
+8. **Render `text` kind.** Update render to handle `text` complements (decode base64, render as plain card with custom label).
+9. **E2E tests.** All 7 from above.
+10. **Manual smoke.** Karl tests on Safari mobile.
+
+## Out of scope (explicit, won't be in this PR)
+
+- Editing custom text after add (delete + re-add).
+- Searching workout-session history (lib/workout-log) for "what I did last time."
+- Reordering complements within an exercise (drag-to-reorder).
+- A "favorites" or "recently used" pinned section in the picker.
+- Hotkey to focus search input (mobile-first; keyboard hotkeys are low priority).
+- Searching across HEP exercises.
+
+## Open questions
+
+None blocking. The spec answers issue #114's open points by committing to the substring-match algorithm and the always-show-curated-default behavior.

--- a/e2e/test_ad_hoc_supersets.py
+++ b/e2e/test_ad_hoc_supersets.py
@@ -83,3 +83,30 @@ def test_remove_custom_text(app_page: Page):
     expect(card).to_be_visible()
     card.get_by_role("button", name="Remove complement").click()
     expect(app_page.get_by_test_id("superset-card").filter(has_text="My custom move")).to_have_count(0)
+
+
+def test_complement_persistence(app_page: Page):
+    """A lib complement and a text complement both survive a page reload."""
+    open_picker_for_first_exercise(app_page)
+
+    # Add a lib complement
+    app_page.get_by_test_id("complement-search").fill("bench")
+    catalog_rows = app_page.get_by_test_id("complement-result").filter(has_text="CATALOG")
+    catalog_title = catalog_rows.first.locator("span.text-sm").inner_text()
+    catalog_rows.first.click()
+
+    # Switch to custom-text and add one
+    app_page.get_by_test_id("custom-text-toggle").click()
+    app_page.get_by_test_id("custom-text-input").fill("Persisted custom move")
+    app_page.get_by_test_id("custom-text-save").click()
+
+    # Reload
+    app_page.reload()
+    app_page.wait_for_selector("[data-testid='app-container']", timeout=15000)
+
+    # Both cards still visible (re-expand the first row first)
+    first_row = app_page.get_by_test_id("exercise-row").first
+    first_row.click()
+    cards = app_page.get_by_test_id("superset-card")
+    expect(cards.filter(has_text=catalog_title).first).to_be_visible()
+    expect(cards.filter(has_text="Persisted custom move").first).to_be_visible()

--- a/e2e/test_ad_hoc_supersets.py
+++ b/e2e/test_ad_hoc_supersets.py
@@ -20,3 +20,19 @@ def test_picker_has_search_and_results(app_page: Page):
     # At least one result row appears with a source label
     rows = app_page.get_by_test_id("complement-result")
     expect(rows.first).to_be_visible()
+
+
+def test_filter_chip_narrows_results(app_page: Page):
+    """Activating a single filter chip removes results from other sources."""
+    open_picker_for_first_exercise(app_page)
+    # Establish baseline: at least one non-catalog row exists
+    pre_count = app_page.get_by_test_id("complement-result").count()
+    assert pre_count > 0
+
+    # Activate the Nearby chip — only NEARBY-labeled rows should remain
+    app_page.get_by_test_id("filter-chip-nearby").click()
+    rows = app_page.get_by_test_id("complement-result")
+    # Every visible result row's label badge must say NEARBY
+    for i in range(rows.count()):
+        badge = rows.nth(i).locator("span", has_text="NEARBY")
+        expect(badge).to_be_visible()

--- a/e2e/test_ad_hoc_supersets.py
+++ b/e2e/test_ad_hoc_supersets.py
@@ -45,3 +45,18 @@ def test_search_finds_catalog_exercise(app_page: Page):
     rows = app_page.get_by_test_id("complement-result")
     catalog_rows = rows.filter(has_text="CATALOG")
     expect(catalog_rows.first).to_be_visible()
+
+
+def test_add_lib_complement(app_page: Page):
+    """Tapping a CATALOG result adds a lib-kind card under the parent exercise."""
+    open_picker_for_first_exercise(app_page)
+    app_page.get_by_test_id("complement-search").fill("bench")
+    catalog_rows = app_page.get_by_test_id("complement-result").filter(has_text="CATALOG")
+    first = catalog_rows.first
+    title = first.locator("span.text-sm").inner_text()  # exercise name
+    first.click()
+    # Close picker — scope to complement-picker to avoid strict-mode violation
+    app_page.get_by_test_id("complement-picker").get_by_role("button", name="Done").click()
+    # The first exercise row now has a superset-card with that title
+    cards = app_page.get_by_test_id("superset-card")
+    expect(cards.filter(has_text=title).first).to_be_visible()

--- a/e2e/test_ad_hoc_supersets.py
+++ b/e2e/test_ad_hoc_supersets.py
@@ -60,3 +60,26 @@ def test_add_lib_complement(app_page: Page):
     # The first exercise row now has a superset-card with that title
     cards = app_page.get_by_test_id("superset-card")
     expect(cards.filter(has_text=title).first).to_be_visible()
+
+
+def test_add_custom_text_complement(app_page: Page):
+    """Custom-text save creates a card with the typed string under the exercise."""
+    open_picker_for_first_exercise(app_page)
+    app_page.get_by_test_id("custom-text-toggle").click()
+    app_page.get_by_test_id("custom-text-input").fill("Cossack squat 3x8")
+    app_page.get_by_test_id("custom-text-save").click()
+    expect(app_page.get_by_test_id("complement-picker")).not_to_be_visible()
+    cards = app_page.get_by_test_id("superset-card")
+    expect(cards.filter(has_text="Cossack squat 3x8").first).to_be_visible()
+
+
+def test_remove_custom_text(app_page: Page):
+    """Tapping the × on a custom-text card removes it from the workout."""
+    open_picker_for_first_exercise(app_page)
+    app_page.get_by_test_id("custom-text-toggle").click()
+    app_page.get_by_test_id("custom-text-input").fill("My custom move")
+    app_page.get_by_test_id("custom-text-save").click()
+    card = app_page.get_by_test_id("superset-card").filter(has_text="My custom move").first
+    expect(card).to_be_visible()
+    card.get_by_role("button", name="Remove complement").click()
+    expect(app_page.get_by_test_id("superset-card").filter(has_text="My custom move")).to_have_count(0)

--- a/e2e/test_ad_hoc_supersets.py
+++ b/e2e/test_ad_hoc_supersets.py
@@ -36,3 +36,12 @@ def test_filter_chip_narrows_results(app_page: Page):
     for i in range(rows.count()):
         badge = rows.nth(i).locator("span", has_text="NEARBY")
         expect(badge).to_be_visible()
+
+
+def test_search_finds_catalog_exercise(app_page: Page):
+    """Typing 'bench' surfaces a CATALOG-labeled result from EX."""
+    open_picker_for_first_exercise(app_page)
+    app_page.get_by_test_id("complement-search").fill("bench")
+    rows = app_page.get_by_test_id("complement-result")
+    catalog_rows = rows.filter(has_text="CATALOG")
+    expect(catalog_rows.first).to_be_visible()

--- a/e2e/test_ad_hoc_supersets.py
+++ b/e2e/test_ad_hoc_supersets.py
@@ -1,0 +1,22 @@
+"""E2E tests for the ad-hoc supersets / universal complement picker."""
+
+from playwright.sync_api import Page, expect
+
+
+def open_picker_for_first_exercise(page: Page) -> None:
+    """Open the complement picker for the first exercise on Today."""
+    page.get_by_test_id("tab-workout").click()
+    # Expand first exercise so its "+ complement" button is visible
+    first_row = page.get_by_test_id("exercise-row").first
+    first_row.click()
+    first_row.get_by_role("button", name="Add complement").first.click()
+    expect(page.get_by_test_id("complement-picker")).to_be_visible()
+
+
+def test_picker_has_search_and_results(app_page: Page):
+    """Picker renders a search input and shows a flat list of curated results."""
+    open_picker_for_first_exercise(app_page)
+    expect(app_page.get_by_test_id("complement-search")).to_be_visible()
+    # At least one result row appears with a source label
+    rows = app_page.get_by_test_id("complement-result")
+    expect(rows.first).to_be_visible()

--- a/e2e/test_ad_hoc_supersets.py
+++ b/e2e/test_ad_hoc_supersets.py
@@ -23,19 +23,23 @@ def test_picker_has_search_and_results(app_page: Page):
 
 
 def test_filter_chip_narrows_results(app_page: Page):
-    """Activating a single filter chip removes results from other sources."""
+    """Activating a single filter chip narrows results to that source only."""
     open_picker_for_first_exercise(app_page)
-    # Establish baseline: at least one non-catalog row exists
     pre_count = app_page.get_by_test_id("complement-result").count()
-    assert pre_count > 0
+    assert pre_count > 0, "expected baseline complements on a fresh state"
 
-    # Activate the Nearby chip — only NEARBY-labeled rows should remain
-    app_page.get_by_test_id("filter-chip-nearby").click()
+    # Activate the Core chip — only CORE-labeled rows should remain
+    app_page.get_by_test_id("filter-chip-core").click()
     rows = app_page.get_by_test_id("complement-result")
-    # Every visible result row's label badge must say NEARBY
-    for i in range(rows.count()):
-        badge = rows.nth(i).locator("span", has_text="NEARBY")
-        expect(badge).to_be_visible()
+    post_count = rows.count()
+    assert post_count > 0, "expected core complements on the default workout"
+    assert post_count <= pre_count, "core filter should not add results"
+    # Every visible result row's label must indicate a core region (not e.g. NEARBY/CATALOG/PT)
+    forbidden_labels = ["NEARBY", "CATALOG", "PT", "L-LEG", "MOBILITY", "STRETCH", "BREATH"]
+    for i in range(post_count):
+        text = rows.nth(i).inner_text()
+        for bad in forbidden_labels:
+            assert bad not in text, f"row {i} contained forbidden label {bad}: {text}"
 
 
 def test_search_finds_catalog_exercise(app_page: Page):


### PR DESCRIPTION
## Summary
- Replaces the source-stacked complement picker with a universal search input + filter chips (`All / Catalog / Nearby / L-Leg / Core / Mobility / PT`).
- Adds two new ComplementId kinds: `lib|<exercise-name>` (any catalog entry from `EX`) and `text|<base64>` (free text the user types).
- Renders both new kinds as cards under the parent exercise — both removable via the existing × button.
- Catalog (`EX`) is gated to non-empty query OR \"Catalog\"-only filter so the picker doesn't drown the user in 100+ exercises by default.

## Test plan
- [x] `e2e/test_ad_hoc_supersets.py` — 7 new tests: picker search/results render, filter chips narrow, catalog search surfaces, lib add, custom-text add, custom-text remove, persistence across reload.
- [x] Full E2E suite: 154 passed, 23 skipped, 0 failures.
- [x] \`tsc --noEmit\` clean. \`npm run build\` succeeds.
- [ ] Manual smoke on Safari mobile (post-merge on nfit.93.fyi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)