### PR TITLE
fix(ci): drop unsupported --yes flag from preview-alias workflow

### DIFF
--- a/.github/workflows/preview-alias.yml
+++ b/.github/workflows/preview-alias.yml
@@ -68,5 +68,4 @@ jobs:
           echo "Aliasing preview.nfit.93.fyi → $DEPLOYMENT_URL"
           npx -y vercel@latest alias "$DEPLOYMENT_URL" preview.nfit.93.fyi \
             --token "$VERCEL_TOKEN" \
-            --scope karlmarxs-projects \
-            --yes
+            --scope karlmarxs-projects


### PR DESCRIPTION
vercel alias rejects --yes. Removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)