### PR TITLE
feat(hep): add calf raise, bilateral leg press, KB RDL, TRX squat

### DIFF
--- a/e2e/test_hep_daily.py
+++ b/e2e/test_hep_daily.py
@@ -34,8 +34,8 @@ def test_hep_pill_renders_on_today_tab(app_page: Page):
     pill = app_page.get_by_test_id("hep-block-pill")
     expect(pill).to_be_visible()
 
-    # Count should match the seeded HEP_EXERCISES length (6 as of May 6).
-    expect(pill).to_have_attribute("data-hep-total", "6")
+    # Count should match the seeded HEP_EXERCISES length (10 as of May 13).
+    expect(pill).to_have_attribute("data-hep-total", "10")
     expect(pill).to_have_attribute("data-hep-done", "0")
 
 
@@ -82,9 +82,9 @@ def test_hep_full_block_renders_on_rehab_tab(app_page: Page):
 
     full = app_page.get_by_test_id("hep-block-full")
     expect(full).to_be_visible()
-    expect(full).to_have_attribute("data-hep-total", "6")
+    expect(full).to_have_attribute("data-hep-total", "10")
 
-    # All six rows should be visible immediately (no toggle).
+    # All ten rows should be visible immediately (no toggle).
     for ex_id in [
         "hep_prone_hip_extension",
         "hep_hip_abduction_sidelying",
@@ -92,6 +92,10 @@ def test_hep_full_block_renders_on_rehab_tab(app_page: Page):
         "hep_bridging_ball_squeeze",
         "hep_isometric_hip_er_prone_ball",
         "hep_band_sidelying_clamshell",
+        "hep_calf_raise",
+        "hep_bilateral_leg_press",
+        "hep_kb_rdl",
+        "hep_trx_squat",
     ]:
         expect(app_page.get_by_test_id(f"hep-row-{ex_id}")).to_be_visible()
 
@@ -119,7 +123,7 @@ def test_hep_strip_renders_at_end_of_today_workout(app_page: Page):
     # Today's workoutKey can vary by day-of-week — assert at least one strip exists.
     strips = app_page.locator("[data-testid^='hep-strip-']")
     expect(strips.first).to_be_visible()
-    expect(strips.first).to_have_attribute("data-hep-total", "6")
+    expect(strips.first).to_have_attribute("data-hep-total", "10")
 
 
 def test_hep_strip_completion_syncs_with_pill(app_page: Page):

--- a/lib/hep-exercises.ts
+++ b/lib/hep-exercises.ts
@@ -107,6 +107,46 @@ export const HEP_EXERCISES: HEPExercise[] = [
     side: "left",
     prescribedOn: "2026-05-06",
   },
+  {
+    id: "hep_calf_raise",
+    name: "Calf Raise",
+    instructions:
+      "Stand with feet hip-width on a flat surface, fingertips on a rail or counter for balance. Press up onto the balls of both feet, lifting your heels as high as possible. Hold briefly at the top, then lower with control until heels touch the floor. Keep weight even between both feet.",
+    sets: 3,
+    reps: 10,
+    side: "bilateral",
+    prescribedOn: "2026-05-13",
+  },
+  {
+    id: "hep_bilateral_leg_press",
+    name: "Bilateral Leg Press",
+    instructions:
+      "Set up on a leg press machine with both feet placed shoulder-width on the platform. Brace your core, then lower the platform under control until knees reach roughly 90° (keep hips below 90° of flexion). Press back to near-lockout without snapping the knees. Keep weight evenly distributed between both legs — do not let the right side dominate.",
+    sets: 3,
+    reps: 10,
+    side: "bilateral",
+    prescribedOn: "2026-05-13",
+  },
+  {
+    id: "hep_kb_rdl",
+    name: "Kettlebell Romanian Deadlift (RDL)",
+    instructions:
+      "Stand with feet hip-width, holding a kettlebell in front of your thighs with both hands. Keeping a soft bend in the knees and a flat back, hinge at the hips to lower the kettlebell along the front of your legs until you feel a stretch in the hamstrings. Drive through both heels and squeeze the glutes to return to standing. Keep weight even between both feet.",
+    sets: 3,
+    reps: 10,
+    side: "bilateral",
+    prescribedOn: "2026-05-13",
+  },
+  {
+    id: "hep_trx_squat",
+    name: "TRX Squat",
+    instructions:
+      "Face the TRX anchor and hold a handle in each hand at chest height with elbows close to the ribs. Step back until the straps are taut and stand with feet hip-width. Sit back and down into a squat, letting the straps unload some of your bodyweight as needed. Drive through both heels to stand. Keep weight even between both feet and knees tracking over toes.",
+    sets: 3,
+    reps: 10,
+    side: "bilateral",
+    prescribedOn: "2026-05-13",
+  },
 ];
 
 /** Active HEP exercises — excludes anything with `retiredOn` set. */


### PR DESCRIPTION
## Summary
- Appends 4 new PT-prescribed daily exercises to `lib/hep-exercises.ts`:
  - `hep_calf_raise` — Calf Raise (bilateral, 3×10)
  - `hep_bilateral_leg_press` — Bilateral Leg Press (bilateral, 3×10)
  - `hep_kb_rdl` — Kettlebell Romanian Deadlift (bilateral, 3×10)
  - `hep_trx_squat` — TRX Squat (bilateral, 3×10)
- All entries `prescribedOn: 2026-05-13` and `side: "bilateral"` to respect the PWB-phase rule against axial compression through the left femoral neck (CLAUDE.md: "NO left squat, NO left leg press"; bilateral lower-body work allowed).
- Append-only — no existing entries modified, no schema changes.

## Notes / open items
- Sets/reps defaulted to **3×10** to match the rest of the HEP file. If the PT printout prescribes different dosing (e.g. 3×8 on the leg press, lower reps for loaded RDLs), update the `sets`/`reps` fields directly.
- No `videoUrl` / `figureUrl` set — fill in from the HEP2GO printout when available.

## Test plan
- [x] `tsc --noEmit` passes (type-check clean)
- [ ] Load `/` in dev, confirm the HEP block on the Today tab shows all 10 entries
- [ ] Verify checkboxes persist to `nwb_hep_done_<YYYY-MM-DD>` localStorage key
- [ ] Confirm Playwright suite still green on PR CI

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8SYvdUktNJL3BgR2vCP6e)_