### PR TITLE
fix(swap): group machine variants by own equipment, not parent's

### DIFF
--- a/.github/workflows/preview-alias.yml
+++ b/.github/workflows/preview-alias.yml
@@ -68,5 +68,4 @@ jobs:
           echo "Aliasing preview.nfit.93.fyi → $DEPLOYMENT_URL"
           npx -y vercel@latest alias "$DEPLOYMENT_URL" preview.nfit.93.fyi \
             --token "$VERCEL_TOKEN" \
-            --scope karlmarxs-projects \
-            --yes
+            --scope karlmarxs-projects

--- a/components/equipment-swap-panel.tsx
+++ b/components/equipment-swap-panel.tsx
@@ -5,6 +5,17 @@ import type { Exercise, MachineVariant } from "@/lib/exercises";
 import { EX, EQUIPMENT, isExerciseAvailable } from "@/lib/exercises";
 import { cssAlpha } from "@/lib/css-utils";
 
+/**
+ * Resolve a variant's effective equipment requirements. Variants may override
+ * the parent exercise's `requires` (e.g. a Smith-machine variant of a DB lift)
+ * — when they don't, they inherit the parent's. Used by the swap panel so that
+ * cross-equipment variants render under their actual equipment group instead
+ * of being lumped under the parent's primary.
+ */
+function variantRequires(variant: MachineVariant, parent: Exercise): string[] {
+  return variant.requires ?? parent.requires;
+}
+
 // ── Equipment category mapping ──────────────────────────────────────────
 
 interface EquipCategoryInfo {
@@ -23,6 +34,9 @@ const EQUIP_CATEGORIES: Record<string, EquipCategoryInfo> = {
   pecdeck: { label: "Pec Deck / Fly Machine", icon: "🦋", order: 7 },
   dipMachine: { label: "Dip Machine", icon: "⬇️", order: 8 },
   preacher: { label: "Preacher Bench", icon: "💺", order: 9 },
+  rowMachine: { label: "Row Machine (Chest-Pad)", icon: "🏋️", order: 8 },
+  tbar: { label: "T-Bar / Landmine Row", icon: "🔩", order: 8 },
+  smith: { label: "Smith Machine", icon: "🛠️", order: 8 },
   barbell: { label: "Barbell", icon: "🏋️", order: 9 },
   dumbbells: { label: "Dumbbells", icon: "💪", order: 10 },
   ezbar: { label: "EZ-Bar", icon: "🔩", order: 11 },
@@ -69,6 +83,8 @@ interface EquipmentGroup {
   icon: string;
   order: number;
   options: SwapOption[];
+  /** Machine variants that should render under this group (filtered by effective requires). */
+  variants: MachineVariant[];
   hasCurrentExercise: boolean;
 }
 
@@ -101,42 +117,56 @@ export default function EquipmentSwapPanel({
   const groups = useMemo(() => {
     const groupMap = new Map<string, EquipmentGroup>();
 
-    const currentKey = getPrimaryEquipKey(currentExercise.requires);
-    const currentCat = getCategoryInfo(currentKey);
-    groupMap.set(currentKey, {
-      key: currentKey,
-      label: currentCat.label,
-      icon: currentCat.icon,
-      order: currentCat.order,
-      options: [
-        { name: currentName, ex: currentExercise, isCurrent: true },
-      ],
-      hasCurrentExercise: true,
-    });
-
-    const availableSwaps = (currentExercise.swaps ?? []).filter(
-      (sw) => !workoutExercises.includes(sw) || sw === currentName,
-    );
-
-    for (const swapName of availableSwaps) {
-      const swapEx = EX[swapName];
-      if (!swapEx) continue;
-
-      const equipKey = getPrimaryEquipKey(swapEx.requires);
-      const cat = getCategoryInfo(equipKey);
-
-      if (!groupMap.has(equipKey)) {
-        groupMap.set(equipKey, {
+    /** Get-or-create a group keyed by primary equipment. */
+    function ensureGroup(equipKey: string): EquipmentGroup {
+      let group = groupMap.get(equipKey);
+      if (!group) {
+        const cat = getCategoryInfo(equipKey);
+        group = {
           key: equipKey,
           label: cat.label,
           icon: cat.icon,
           order: cat.order,
           options: [],
+          variants: [],
           hasCurrentExercise: false,
-        });
+        };
+        groupMap.set(equipKey, group);
       }
+      return group;
+    }
 
-      const group = groupMap.get(equipKey)!;
+    // Seed the current exercise's group with the exercise itself.
+    const currentKey = getPrimaryEquipKey(currentExercise.requires);
+    const currentGroup = ensureGroup(currentKey);
+    currentGroup.options.push({
+      name: currentName,
+      ex: currentExercise,
+      isCurrent: true,
+    });
+    currentGroup.hasCurrentExercise = true;
+
+    // Distribute machine variants into groups by their effective requires.
+    // Variants that share the parent's primary equipment land in the current
+    // group; cross-equipment variants (Smith machine variant of a DB lift,
+    // cable variant of a chest-supported row, etc.) get their own group.
+    for (const variant of currentExercise.machineVariants ?? []) {
+      const variantKey = getPrimaryEquipKey(
+        variantRequires(variant, currentExercise),
+      );
+      const group = ensureGroup(variantKey);
+      group.variants.push(variant);
+    }
+
+    // Swap candidates (other named exercises).
+    const availableSwaps = (currentExercise.swaps ?? []).filter(
+      (sw) => !workoutExercises.includes(sw) || sw === currentName,
+    );
+    for (const swapName of availableSwaps) {
+      const swapEx = EX[swapName];
+      if (!swapEx) continue;
+      const equipKey = getPrimaryEquipKey(swapEx.requires);
+      const group = ensureGroup(equipKey);
       if (!group.options.some((o) => o.name === swapName)) {
         group.options.push({ name: swapName, ex: swapEx, isCurrent: false });
       }
@@ -149,11 +179,12 @@ export default function EquipmentSwapPanel({
     });
   }, [currentName, currentExercise, workoutExercises]);
 
-  const variants = currentExercise.machineVariants;
-  const hasVariantsOrSwaps =
-    (groups.length > 1) ||
-    (groups[0]?.options.length > 1) ||
-    (variants && variants.length > 0);
+  const hasVariantsOrSwaps = groups.some(
+    (g) =>
+      g.options.length > 0 || g.variants.length > 0,
+  ) && (groups.length > 1 ||
+    groups[0]?.options.length > 1 ||
+    groups[0]?.variants.length > 0);
 
   if (!hasVariantsOrSwaps) return null;
 
@@ -171,10 +202,7 @@ export default function EquipmentSwapPanel({
               o.ex.requires.length > 0 && !isExerciseAvailable(o.ex, equipment),
           );
 
-          // Count includes variants for the current group
-          const totalCount =
-            group.options.length +
-            (group.hasCurrentExercise && variants ? variants.length : 0);
+          const totalCount = group.options.length + group.variants.length;
 
           return (
             <div
@@ -235,14 +263,16 @@ export default function EquipmentSwapPanel({
               {/* Expanded options */}
               {isExpanded && (
                 <div className="px-3 pb-3 space-y-1.5">
-                  {/* Machine variants (only in the current equipment group) */}
-                  {group.hasCurrentExercise && variants && variants.length > 0 && (
+                  {/* Machine variants — bucketed under their effective equipment group */}
+                  {group.variants.length > 0 && (
                     <div>
                       <div className="text-[10px] font-bold text-text-muted uppercase tracking-wider mb-1.5">
-                        Machine type at your station
+                        {group.hasCurrentExercise
+                          ? "Machine type at your station"
+                          : "Alternate station — same exercise"}
                       </div>
                       <div className="grid grid-cols-2 gap-2">
-                        {variants.map((variant) => {
+                        {group.variants.map((variant) => {
                           const isSelected = selectedVariantId === variant.id;
                           const isConditional = variant.status === "conditional";
                           const statusLabel =
@@ -347,7 +377,7 @@ export default function EquipmentSwapPanel({
                   )}
 
                   {/* Separator if we have both variants and swap options */}
-                  {group.hasCurrentExercise && variants && variants.length > 0 && group.options.length > 0 && (
+                  {group.variants.length > 0 && group.options.length > 0 && (
                     <div className="border-t border-border my-1" />
                   )}
 

--- a/lib/exercises.ts
+++ b/lib/exercises.ts
@@ -193,6 +193,9 @@ export const EQUIPMENT: Record<string, EquipmentItem> = {
   dipMachine: { name: "Dip Machine", icon: "\u2B07\uFE0F", category: "machines" },
   preacher: { name: "Preacher Bench", icon: "\u{1F4BA}", category: "machines" },
   hamcurl: { name: "Ham Curl Machine", icon: "\u{1F9B5}", category: "machines" },
+  rowMachine: { name: "Row Machine (Chest-Pad)", icon: "\u{1F3CB}️", category: "machines" },
+  tbar: { name: "T-Bar / Landmine Row", icon: "\u{1F529}", category: "machines" },
+  smith: { name: "Smith Machine", icon: "\u{1F6E0}️", category: "machines" },
   pullupbar: { name: "Pull-Up Bar", icon: "\u{1FA9C}", category: "functional" },
   rings: { name: "Gymnastic Rings", icon: "\u2B55", category: "functional" },
   battleRopes: { name: "Battle Ropes", icon: "\u{1FAA2}", category: "cardio" },
@@ -921,6 +924,7 @@ export const EX: Record<string, Exercise> = {
         label: "Free Cable + Bar",
         icon: "\u2696\uFE0F",
         description: "Standard cable station with a wide lat pulldown bar attachment",
+        requires: ["cables"],
         setupCues: [
           "Attach wide bar to high pulley",
           "Sit on bench or floor below the cable",
@@ -932,6 +936,7 @@ export const EX: Record<string, Exercise> = {
         label: "Free Cable + V-Bar",
         icon: "\u2696\uFE0F",
         description: "Cable station with V-bar for neutral-grip lat pulldown variation",
+        requires: ["cables"],
         setupCues: [
           "Attach V-bar handle to high pulley",
           "Sit below cable, lean back slightly",
@@ -943,6 +948,7 @@ export const EX: Record<string, Exercise> = {
         label: "Band at Rack",
         icon: "\u{1F380}",
         description: "Heavy resistance band looped over a high point on a power rack",
+        requires: ["bands"],
         setupCues: [
           "Loop band over top of rack or pull-up bar",
           "Sit on the floor or a low bench below the band",
@@ -1069,6 +1075,7 @@ export const EX: Record<string, Exercise> = {
         icon: "\u{1F3CB}️",
         description: "Plate-loaded chest-pad row with independent handles per arm",
         status: "preferred",
+        requires: ["rowMachine"],
         setupCues: [
           "Seated facing the chest pad, plates loaded evenly on the horizontal pegs",
           "Chest pad and seat take all torso load — both legs stay passive, no bracing",
@@ -1081,6 +1088,7 @@ export const EX: Record<string, Exercise> = {
         icon: "\u{1F4CC}",
         description: "Cybex / Life Fitness pin-loaded seated row with chest pad",
         status: "preferred",
+        requires: ["rowMachine"],
         setupCues: [
           "Seated facing the chest pad, pin-select the working weight",
           "Chest pad supports the torso — both legs passive, identical setup to Hammer Strength",
@@ -1093,6 +1101,7 @@ export const EX: Record<string, Exercise> = {
         icon: "⚖️",
         description: "Cable row from a bench with V-handle, wide bar, or rope — right-foot-only bracing",
         status: "secondary",
+        requires: ["cables", "bench"],
         setupCues: [
           "Sit on the bench, hinge from the hips, scoot back so hip flexion stays under 90°",
           "Brace ONLY the right foot on the platform — left leg hangs free off the side or rests passively with zero load",
@@ -1105,6 +1114,7 @@ export const EX: Record<string, Exercise> = {
         icon: "⚖️",
         description: "Single D-handle cable row — unilateral, naturally caps load",
         status: "secondary",
+        requires: ["cables", "bench"],
         setupCues: [
           "Same setup as the bilateral cable row — right foot on the platform, left leg passive",
           "Single D-handle, one arm at a time — the lighter load helps prevent left-foot bracing under fatigue",
@@ -1117,6 +1127,7 @@ export const EX: Record<string, Exercise> = {
         icon: "⚠️",
         description: "Plate-loaded chest-pad T-bar — ONLY if the machine has a kneeling pad",
         status: "conditional",
+        requires: ["tbar"],
         caveat: "Only use this machine if it has a kneeling pad: park the right knee on the pad, left leg dangles free. If the machine is foot-plate-only, SKIP IT — the bilateral leg-bracing demand under heavy load is too high. Standing T-bar / landmine T-bar variants are NOT NWB-safe (bilateral hip hinge) and must be excluded entirely.",
         setupCues: [
           "Verify the machine has a kneeling pad before loading — if foot-plate-only, abort and pick a different variant",


### PR DESCRIPTION
Original branch was created before dev → main fast-forward, so the diff also includes PR #121's CI fix (already in main but not yet in dev). Both ride along — clean.

## Symptom (Karl-reported)

Pull A → Chest-Supported DB Row → \"Equipment & Alternatives\" shows a \"Dumbbells (6)\" group containing 5 non-dumbbell stations (Hammer Strength, selectorized chest-pad row, two cable rows, T-bar). Misleading.

## Root cause

\`MachineVariant.requires\` was optional and \"inherits parent\" by default. All 6 variants were inheriting the parent exercise's \`requires=['dumbbells','bench']\` even when the variant actually used a row machine / cables / T-bar. The swap panel grouped by \`getPrimaryEquipKey(parent.requires)\` → all 6 lumped under \"Dumbbells\".

## Fix

1. **UI (\`components/equipment-swap-panel.tsx\`)** — Group machine variants by their effective \`requires\` (\`variant.requires ?? parent.requires\`). Each EquipmentGroup now has its own \`variants[]\` array. Cross-equipment variants peel off into the correct group.

2. **Data (\`lib/exercises.ts\`)** — Added 3 new equipment keys (\`rowMachine\`, \`tbar\`, \`smith\`) + explicit \`requires\` on:
   - Chest-Supported DB Row: 5 cross-equipment variants tagged
   - Lat Pulldown (Wide): cable + band variants tagged

## What you'll see after merge

| Exercise | Before | After |
|---|---|---|
| Chest-Supported DB Row | Dumbbells (6) all lumped | Dumbbells (1) + Row Machine (2) + Cable Station (2) + T-Bar (1) |
| Lat Pulldown (Wide) | Lat Pulldown (4) all lumped | Lat Pulldown (1) + Cable Station (2) + Resistance Bands (1) |

## Broader audit

Issue #122 tracks ~12 more exercises with cross-equipment variants still inheriting parent requires. Foundation is now in place — those just need explicit \`requires\` tags on each variant.

## Test plan

- [x] tsc clean, build clean
- [x] Full E2E: 154 passed, 23 skipped
- [x] Live on preview.nfit.93.fyi for visual smoke (auto-alias active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)