### PR TITLE
feat(fwb): advance program clock to the FWB phase

### DIFF
--- a/components/progress-clock.tsx
+++ b/components/progress-clock.tsx
@@ -5,6 +5,7 @@ import {
   DEFAULT_PROGRAM_PHASES,
   ProgramPhase,
   activePhase,
+  ensureFwbPhase,
   phaseDayNumber,
   phaseDurationMs,
   phaseElapsedMs,
@@ -44,7 +45,14 @@ function loadPhases(): ProgramPhase[] {
   // loadState returns the raw JSON-parsed object (Dates are strings until rehydrated).
   const raw = loadState<unknown>(STORAGE_KEY, null);
   const parsed = parsePhases(raw);
-  if (parsed && parsed.length > 0) return parsed;
+  if (parsed && parsed.length > 0) {
+    // Forward-migrate arrays persisted before the FWB phase existed.
+    const migrated = ensureFwbPhase(parsed);
+    if (migrated !== parsed && typeof window !== "undefined") {
+      saveState(STORAGE_KEY, migrated);
+    }
+    return migrated;
+  }
   // First-run fallback: write defaults so future sessions are stable.
   if (typeof window !== "undefined") {
     saveState(STORAGE_KEY, DEFAULT_PROGRAM_PHASES);

--- a/components/workout-view.tsx
+++ b/components/workout-view.tsx
@@ -21,7 +21,7 @@ import {
   MOBILITY_SUPPLEMENTS,
 } from "@/lib/supplements";
 import type { Exercise } from "@/lib/exercises";
-import { computeCurrentPhase } from "@/lib/program";
+import { computeCurrentPhase, isContentProgramComplete } from "@/lib/program";
 import Section from "@/components/section";
 import ExerciseRow from "@/components/exercise-row";
 import Callout from "@/components/callout";
@@ -545,10 +545,17 @@ const EQUIPMENT_CORE_BLOCKS: {
 export default function WorkoutView() {
   // ----- State -----
   const [tab, setTab] = useState(() => loadState<number>("nwb_tab", 0));
-  // Phase is derived from the program start date — always opens on the
-  // week that matches the calendar. Tapping a pill temporarily overrides
-  // within the session but doesn't persist; next mount re-syncs.
-  const [phase, setPhase] = useState(() => computeCurrentPhase());
+  // Phase is derived from the program start date — opens on the week that
+  // matches the calendar. Once the 8-week content program is complete (FWB
+  // era), it opens deselected (`null`) since the week-1–8 phases no longer
+  // apply. Tapping a pill overrides within the session but doesn't persist;
+  // next mount re-syncs.
+  const [phase, setPhase] = useState<number | null>(() =>
+    isContentProgramComplete() ? null : computeCurrentPhase(),
+  );
+  // Effective phase for exercise gating + set-scheme indexing: when no tab is
+  // selected (FWB era) everything is unlocked, so fall back to the last phase.
+  const effPhase = phase ?? PHASES.length - 1;
   const [openSections, setOpenSections] = useState<Record<string, boolean>>(
     () => {
       const sd = loadState<number>("nwb_startDay", 0);
@@ -1242,7 +1249,7 @@ export default function WorkoutView() {
         <ExerciseRow
           name={name}
           ex={ex}
-          phase={phase}
+          phase={effPhase}
           isExpanded={!!expandedEx[name]}
           onToggle={() => toggleEx(name)}
           onLongPress={() =>
@@ -1309,7 +1316,7 @@ export default function WorkoutView() {
               const exItem = EX[nm];
               return { orig, name: nm, ex: exItem };
             })
-            .filter(({ ex: exItem }) => exItem && (exItem.phase == null || phase >= exItem.phase));
+            .filter(({ ex: exItem }) => exItem && (exItem.phase == null || effPhase >= exItem.phase));
 
           // Build focus items with supplements attached (auto + user-opted-in only)
           const items: FocusItem[] = activeExercises.map(({ name: nm, ex: exItem }) => {
@@ -1513,7 +1520,7 @@ export default function WorkoutView() {
           const exName = getExName(workoutKey, origName);
           const ex = EX[exName];
           if (!ex) return null;
-          if (ex.phase != null && phase < ex.phase) return null;
+          if (ex.phase != null && effPhase < ex.phase) return null;
           const unavail = !isAvailable(exName);
           const isExp = !!expandedEx[exName];
 
@@ -1541,7 +1548,7 @@ export default function WorkoutView() {
               <ExerciseRow
                 name={exName}
                 ex={ex}
-                phase={phase}
+                phase={effPhase}
                 isExpanded={isExp}
                 onToggle={() => toggleEx(exName)}
                 onLongPress={() =>
@@ -1604,7 +1611,7 @@ export default function WorkoutView() {
                   <ExerciseRow
                     name={name}
                     ex={ex}
-                    phase={phase}
+                    phase={effPhase}
                     isExpanded={!!expandedEx[name]}
                     onToggle={() => toggleEx(name)}
                     onLongPress={() =>
@@ -1919,7 +1926,7 @@ export default function WorkoutView() {
                 <ExerciseRow
                   name={k}
                   ex={ex}
-                  phase={phase}
+                  phase={effPhase}
                   isExpanded={!!expandedEx[k]}
                   onToggle={() => toggleEx(k)}
                   onLongPress={() =>
@@ -2761,7 +2768,7 @@ export default function WorkoutView() {
       </div>
 
       {/* Phase selector */}
-      <div className="flex gap-1.5 mb-4">
+      <div className={`flex gap-1.5 ${phase === null ? "mb-1.5" : "mb-4"}`}>
         {PHASES.map((p, i) => (
           <div
             key={i}
@@ -2794,6 +2801,21 @@ export default function WorkoutView() {
           </div>
         ))}
       </div>
+
+      {/* FWB era: the 8-week content phases no longer apply, so no tab is
+          selected. A note explains the deselected state. */}
+      {phase === null && (
+        <div
+          data-testid="phase-selector-fwb-note"
+          className="text-[10px] text-text-muted mb-4 px-1 leading-snug"
+        >
+          <span className="font-semibold" style={{ color: "#facc15" }}>
+            FWB
+          </span>{" "}
+          — base 8-week program complete. Phases above are kept for reference;
+          tap one to preview its set scheme.
+        </div>
+      )}
 
       {/* Tab bar */}
       <div ref={tabBarRef} data-testid="tab-bar" className="relative flex gap-1 mb-5 items-stretch">
@@ -3059,7 +3081,7 @@ export default function WorkoutView() {
         const { items, index } = focusState;
         const item = items[index];
         if (!item) return null;
-        const s = item.ex.sets[phase] ?? item.ex.sets[0];
+        const s = item.ex.sets[effPhase] ?? item.ex.sets[0];
         return (
           <div
             className="fixed inset-0 z-[250] flex flex-col"

--- a/lib/program.ts
+++ b/lib/program.ts
@@ -73,16 +73,35 @@ export interface ProgramPhase {
 }
 
 /**
+ * The Full Weight-Bearing phase. As of 2026-05 the PT progression moved
+ * Karl from PWB to bilateral standing weight-bearing under load monitoring
+ * (see CLAUDE.md "Key Constraints" and the `fnsf_phase_fwb` entry in
+ * lib/conditions/fnsf-left.ts). Color matches the condition pack's FWB phase.
+ */
+export const FWB_PHASE: ProgramPhase = {
+  id: "fwb",
+  name: "FWB",
+  longName: "Full Weight Bearing",
+  startDate: new Date("2026-05-13T16:00:00Z"),
+  durationDays: 28,
+  status: "active",
+  color: "#facc15",
+  desc: "Full weight-bearing return. Bilateral standing patterns (KB RDL, leg press, TRX squat, calf raises) under PT load monitoring at sub-maximal loads.",
+};
+
+/**
  * Default rehab program phases.
  *
  * - NWB: original 8-week non-weight-bearing protocol — completed.
- * - PWB: 6-week partial-weight-bearing extension — active, started
- *   2026-04-29 (positive medical update green-lit weight bearing).
+ * - PWB: partial-weight-bearing extension — completed; started 2026-04-29
+ *   and progressed faster than the planned 6 weeks (PT advanced to FWB on
+ *   2026-05-13, ~2 weeks in).
+ * - FWB: full weight-bearing return — active as of 2026-05-13.
  *
  * On first load (no `nwb_programPhases` key in storage), the
- * `ProgressClock` writes this array. Existing users who never had a
- * persisted phase array get the same defaults — there is no v1 schema to
- * migrate from since `PROG_START` was previously a hardcoded constant.
+ * `ProgressClock` writes this array. Users with a persisted phase array
+ * from before FWB existed are migrated forward by `ensureFwbPhase` so the
+ * clock advances without manual localStorage surgery.
  */
 export const DEFAULT_PROGRAM_PHASES: ProgramPhase[] = [
   {
@@ -100,12 +119,31 @@ export const DEFAULT_PROGRAM_PHASES: ProgramPhase[] = [
     name: "PWB",
     longName: "Partial Weight Bearing",
     startDate: new Date("2026-04-29T16:00:00Z"),
-    durationDays: 42,
-    status: "active",
+    durationDays: 14,
+    status: "completed",
     color: "#10b981",
-    desc: "6-week partial-weight-bearing rehab. PT-guided progression.",
+    desc: "Partial-weight-bearing rehab. PT-guided progression; advanced to FWB ahead of the planned 6-week window.",
   },
+  FWB_PHASE,
 ];
+
+/**
+ * Forward-migrate a persisted phases array to include the FWB phase.
+ *
+ * Returns the array unchanged (same reference) when an `fwb` phase is
+ * already present, so callers can cheaply detect a no-op and skip the
+ * localStorage write. Otherwise marks any currently-active phase as
+ * completed and appends the active FWB phase. Idempotent.
+ */
+export function ensureFwbPhase(phases: ProgramPhase[]): ProgramPhase[] {
+  if (phases.some((p) => p.id === FWB_PHASE.id)) return phases;
+  return [
+    ...phases.map((p) =>
+      p.status === "active" ? { ...p, status: "completed" as const } : p,
+    ),
+    FWB_PHASE,
+  ];
+}
 
 /**
  * Find the currently-active phase. If multiple phases are marked active

--- a/lib/program.ts
+++ b/lib/program.ts
@@ -44,6 +44,19 @@ export function computeCurrentPhase(now: Date = new Date()): number {
   return 3;
 }
 
+/**
+ * True once the 8-week training-content program (Foundation → PWB Prep) is
+ * behind us — i.e. week > 8, which is the FWB era. In this state the Today-tab
+ * phase selector deselects: the week-1–8 content phases no longer apply, so no
+ * tab is highlighted rather than pinning to the final "PWB Prep" tab.
+ */
+export function isContentProgramComplete(now: Date = new Date()): boolean {
+  const elapsed = now.getTime() - PROG_START.getTime();
+  if (elapsed < 0) return false;
+  const week = Math.floor(elapsed / (7 * 24 * 60 * 60 * 1000)) + 1;
+  return week > 8;
+}
+
 // ===== Rehab program phases (NWB / PWB / ...) =====
 
 /**


### PR DESCRIPTION
## Summary

Wire the app's phase mechanisms to reflect that PT progressed Karl into **FWB** (full weight-bearing) in 2026-05 (per `CLAUDE.md` Key Constraints and `fnsf_phase_fwb` in `lib/conditions/fnsf-left.ts`). Two distinct "phase" controls are involved:

### 1. Program clock → now reads FWB
- Add `FWB_PHASE` and make it the active phase in `DEFAULT_PROGRAM_PHASES`; mark PWB completed (it advanced ~2 weeks in, ahead of the planned 6-week window). Color `#facc15` matches the condition pack.
- Add `ensureFwbPhase(phases)` — an **idempotent forward-migration** so a phase array already persisted in `localStorage` (`nwb_programPhases`) from before FWB existed advances on next load, without manual surgery. Wired into `ProgressClock.loadPhases` (only re-persists when something changed).

### 2. Today-tab phase selector → deselects in the FWB era
The calendar-driven selector previously clamped to the final "WK 7-8 / PWB Prep" tab for any date past week 8, implying that phase still applied. It doesn't anymore.
- Add `isContentProgramComplete(now)` (week > 8) to `lib/program`.
- `phase` state is now `number | null`; it opens **deselected** (no tab highlighted) in the FWB era, with a short caption explaining the state (tabs remain tappable to preview a phase's set scheme).
- Exercise gating + set-scheme indexing use a new `effPhase` (null → last phase, so everything stays unlocked); only the selector highlight uses the nullable `phase`.

The FWB workout exercises (`lib/exercises-fwb.ts`) and the Rehab/PT-tab FWB picker already existed — no changes there.

## Prerequisite merged first
- **#125** (`feat(hep): add calf raise, bilateral leg press, KB RDL, TRX squat`) was squash-merged into `dev` first, as requested, and is included here (HEP daily total 6 → 10).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run build` succeeds
- [ ] Progress clock header reads **FWB · Full Weight Bearing**, with NWB + PWB as prior "done" badges
- [ ] An existing session (NWB+PWB already in `localStorage`) advances to FWB on next load
- [ ] Today-tab phase selector shows **no tab selected** with the FWB caption; tapping a tab still previews its set scheme
- [ ] Playwright suite green (progress clock is masked in visual-regression; no phase-content assertions)

https://claude.ai/code/session_01AB8mNges7pncKV1AcU7YtX